### PR TITLE
Finalize pydantic v2

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -313,6 +313,16 @@
       ]
     },
     {
+      "login": "PriOliveira",
+      "name": "Priscila Oliveira",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13801839?v=4",
+      "profile": "https://github.com/PriOliveira",
+      "contributions": [
+        "review",
+        "userTesting"
+      ]
+    },
+    {
       "login": "awoimbee",
       "name": "Arthur Woimbée",
       "avatar_url": "https://avatars.githubusercontent.com/u/22431493?v=4",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -311,6 +311,18 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "awoimbee",
+      "name": "Arthur Woimbée",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22431493?v=4",
+      "profile": "https://github.com/awoimbee",
+      "contributions": [
+        "review",
+        "userTesting",
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           fail_ci_if_error: true
 
-  test-special-version:
+  test-no-erdantic-version:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     environment: ci
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Don't worry - just `pip install autodoc_pydantic` ☺.
 - 📋 shows summary section for model configuration, fields and validators
 - 👀 hides overloaded and redundant model class signature
 - 🔱 visualizes entity-relationship-diagrams for class hierarchies
-- 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 3.5.0`
+- 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 4.0.0`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://img.shields.io/codecov/c/gh/mansenfranzen/autodoc_pydantic?style=for-the-badge)](https://app.codecov.io/gh/mansenfranzen/autodoc_pydantic)
 
 [![Downloads](https://img.shields.io/pypi/dm/autodoc_pydantic?color=fe7d37&style=for-the-badge)](https://pypistats.org/packages/autodoc-pydantic)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-32-orange.svg?style=for-the-badge)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=for-the-badge)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 
@@ -100,6 +100,7 @@ Thanks to great open source projects [sphinx](https://www.sphinx-doc.org/en/mast
       <td align="center" valign="top" width="14.28%"><a href="http://charlie.machalow.com"><img src="https://avatars.githubusercontent.com/u/5749838?v=4?s=100" width="100px;" alt="Charles Machalow"/><br /><sub><b>Charles Machalow</b></sub></a><br /><a href="#question-csm10495" title="Answering Questions">💬</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/tkaraouzene"><img src="https://avatars.githubusercontent.com/u/20064077?v=4?s=100" width="100px;" alt="Thomas Karaouzene"/><br /><sub><b>Thomas Karaouzene</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/issues?q=author%3Atkaraouzene" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/caseyzak24"><img src="https://avatars.githubusercontent.com/u/29411281?v=4?s=100" width="100px;" alt="caseyzak24"/><br /><sub><b>caseyzak24</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/commits?author=caseyzak24" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/awoimbee"><img src="https://avatars.githubusercontent.com/u/22431493?v=4?s=100" width="100px;" alt="Arthur Woimbée"/><br /><sub><b>Arthur Woimbée</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/pulls?q=is%3Apr+reviewed-by%3Aawoimbee" title="Reviewed Pull Requests">👀</a> <a href="#userTesting-awoimbee" title="User Testing">📓</a> <a href="https://github.com/mansenfranzen/autodoc_pydantic/commits?author=awoimbee" title="Code">💻</a> <a href="https://github.com/mansenfranzen/autodoc_pydantic/commits?author=awoimbee" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -28,15 +28,8 @@ Don't worry - just `pip install autodoc_pydantic` ☺.
 - 📎 defines explicit pydantic prefixes for models, settings, fields, validators and model config
 - 📋 shows summary section for model configuration, fields and validators
 - 👀 hides overloaded and redundant model class signature
-- 📚 sorts fields, validators and model config within models by type
-- 🍀 Supports `pydantic >= 1.5.0, < 2.0.0` and `sphinx >= 3.4.0`
-
-### Comparison between autodoc sphinx and autodoc pydantic
-
-[![Comparison](https://raw.githubusercontent.com/mansenfranzen/autodoc_pydantic/main/docs/source/material/example_comparison_v1.0.0.gif)](https://autodoc-pydantic.readthedocs.io/en/latest/examples.html#default-configuration)
-
-To see those features in action, jump over to the [example documentation](https://autodoc-pydantic.readthedocs.io/en/stable/users/examples.html#default-configuration) to compare
-the appearance of standard sphinx autodoc with *autodoc_pydantic*.
+- visualizes entity-relationship-diagrams for class hierarchies
+- 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 3.5.0`
 
 ## Documentation
 
@@ -46,6 +39,14 @@ For more details, please visit the official [documentation](https://autodoc-pyda
 - [Configuration](https://autodoc-pydantic.readthedocs.io/en/stable/users/configuration.html)
 - [Usage](https://autodoc-pydantic.readthedocs.io/en/stable/users/usage.html)
 - [Examples](https://autodoc-pydantic.readthedocs.io/en/stable/users/examples.html)
+
+### Comparison between autodoc sphinx and autodoc pydantic
+
+[![Comparison](https://raw.githubusercontent.com/mansenfranzen/autodoc_pydantic/main/docs/source/material/example_comparison_v1.0.0.gif)](https://autodoc-pydantic.readthedocs.io/en/latest/examples.html#default-configuration)
+
+To see those features in action, jump over to the [example documentation](https://autodoc-pydantic.readthedocs.io/en/stable/users/examples.html#default-configuration) to compare
+the appearance of standard sphinx autodoc with *autodoc_pydantic*.
+
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Don't worry - just `pip install autodoc_pydantic` ☺.
 - 📎 defines explicit pydantic prefixes for models, settings, fields, validators and model config
 - 📋 shows summary section for model configuration, fields and validators
 - 👀 hides overloaded and redundant model class signature
-- visualizes entity-relationship-diagrams for class hierarchies
+- 🔱 visualizes entity-relationship-diagrams for class hierarchies
 - 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 3.5.0`
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://img.shields.io/codecov/c/gh/mansenfranzen/autodoc_pydantic?style=for-the-badge)](https://app.codecov.io/gh/mansenfranzen/autodoc_pydantic)
 
 [![Downloads](https://img.shields.io/pypi/dm/autodoc_pydantic?color=fe7d37&style=for-the-badge)](https://pypistats.org/packages/autodoc-pydantic)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=for-the-badge)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-34-orange.svg?style=for-the-badge)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 
@@ -100,6 +100,7 @@ Thanks to great open source projects [sphinx](https://www.sphinx-doc.org/en/mast
       <td align="center" valign="top" width="14.28%"><a href="http://charlie.machalow.com"><img src="https://avatars.githubusercontent.com/u/5749838?v=4?s=100" width="100px;" alt="Charles Machalow"/><br /><sub><b>Charles Machalow</b></sub></a><br /><a href="#question-csm10495" title="Answering Questions">💬</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/tkaraouzene"><img src="https://avatars.githubusercontent.com/u/20064077?v=4?s=100" width="100px;" alt="Thomas Karaouzene"/><br /><sub><b>Thomas Karaouzene</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/issues?q=author%3Atkaraouzene" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/caseyzak24"><img src="https://avatars.githubusercontent.com/u/29411281?v=4?s=100" width="100px;" alt="caseyzak24"/><br /><sub><b>caseyzak24</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/commits?author=caseyzak24" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/PriOliveira"><img src="https://avatars.githubusercontent.com/u/13801839?v=4?s=100" width="100px;" alt="Priscila Oliveira"/><br /><sub><b>Priscila Oliveira</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/pulls?q=is%3Apr+reviewed-by%3APriOliveira" title="Reviewed Pull Requests">👀</a> <a href="#userTesting-PriOliveira" title="User Testing">📓</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/awoimbee"><img src="https://avatars.githubusercontent.com/u/22431493?v=4?s=100" width="100px;" alt="Arthur Woimbée"/><br /><sub><b>Arthur Woimbée</b></sub></a><br /><a href="https://github.com/mansenfranzen/autodoc_pydantic/pulls?q=is%3Apr+reviewed-by%3Aawoimbee" title="Reviewed Pull Requests">👀</a> <a href="#userTesting-awoimbee" title="User Testing">📓</a> <a href="https://github.com/mansenfranzen/autodoc_pydantic/commits?author=awoimbee" title="Code">💻</a> <a href="https://github.com/mansenfranzen/autodoc_pydantic/commits?author=awoimbee" title="Tests">⚠️</a></td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ For more details, please visit the official [documentation](https://autodoc-pyda
 - [Configuration](https://autodoc-pydantic.readthedocs.io/en/stable/users/configuration.html)
 - [Usage](https://autodoc-pydantic.readthedocs.io/en/stable/users/usage.html)
 - [Examples](https://autodoc-pydantic.readthedocs.io/en/stable/users/examples.html)
+- [Developer Guide](https://autodoc-pydantic.readthedocs.io/en/stable/developers/setup.html)
 
-### Comparison between autodoc sphinx and autodoc pydantic
+## Comparison between autodoc sphinx and autodoc pydantic
 
 [![Comparison](https://raw.githubusercontent.com/mansenfranzen/autodoc_pydantic/main/docs/source/material/example_comparison_v1.0.0.gif)](https://autodoc-pydantic.readthedocs.io/en/latest/examples.html#default-configuration)
 
 To see those features in action, jump over to the [example documentation](https://autodoc-pydantic.readthedocs.io/en/stable/users/examples.html#default-configuration) to compare
 the appearance of standard sphinx autodoc with *autodoc_pydantic*.
-
 
 ## Acknowledgements
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+v2.0.0 - 2023-07-XX
+-------------------
+
+This is a major release supporting pydantic v2.
+
+Features
+~~~~~~~~
+
+TBD
+
+Changed Behavior
+~~~~~~~~~~~~~~~~
+
+TBD
+
+
 v1.9.0 - 2023-06-08
 -------------------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,17 +4,89 @@ Changelog
 v2.0.0 - 2023-07-XX
 -------------------
 
-This is a major release supporting pydantic v2.
+This is a major release supporting pydantic v2. In June 2023, pydantic v2 was
+released while introducing backwards incompatible API and behavioral changes in
+comparison to pydantic v1. Supporting pydantic v2 required substantial
+adjustments to the codebase leading to a new major release of autodoc_pydantic
+(v1.9.0 -> v2.0.0), too.
 
-Features
-~~~~~~~~
-
-TBD
+In order to keep the codebase clean and concise, separate versions for v1 and
+v2 were created. The v2 branch will eventually become the new main branch
+while the code for v1 remains in the main-1.x branch.
 
 Changed Behavior
 ~~~~~~~~~~~~~~~~
 
-TBD
+- Documenting pydantic model configurations in isolation or as a separate
+  member of the pydantic model is no longer available. The following options
+  have been removed:
+
+  - ``autodoc_pydantic_model_show_config_member``
+  - ``autodoc_pydantic_settings_show_config_member``
+  - ``autodoc_pydantic_config_members``
+  - ``autodoc_pydantic_config_signature_prefix``
+
+- All semantic changes from pydantic v1 to v2 take full effect.
+  **autodoc_pydantic** does not modify the underlying behavior of pydantic in
+  any way. Instead, it only documents whatever pydantic exposes. Hence, all
+  behavioral changes such as the new default strict mode are preserved in v2.
+
+- Sphinx ``< 4.0.0`` is no longer supported.
+
+Features
+~~~~~~~~
+
+- Support for pydantic v2 💫.
+- Support annotated type hints.
+
+Internal
+~~~~~~~~
+
+- Adjust imports to refer to ``pydantic-settings`` (v2) instead of ``pydantic`` (v1).
+- Adjust imports to refer to ``field_validator`` (v2) insteaf of ``validator`` (v1).
+- Adjust imports to refer to ``model_validator`` (v2) insteaf of ``root_validator`` (v1).
+- Replace ``pydantic.generics.GenericModel`` (v1) with ``typing.Generic`` (v2).
+- Simplify ``ValidatorAdapter`` and ``ValidatorInspector``.
+- Simplify reused validators retrieval.
+- Completely rewrite the model's field constraint retrieval functionality in ``inspection.FieldInspector``.
+- Adjust model's field serializability checks in ``inspection.FieldInspector``.
+- Replace ``BaseModel`` with ``NamedTuple`` for ``ValidatorAdapter``.
+- Remove obsolete pre/post validator attributes.
+- Introduce ``importlib-metadata`` to fetch version number including support for python 3.7.
+
+Testing
+~~~~~~~
+
+- Remove all obsolete pydantic versions from test matrix.
+- Remove all tests for documenting config members.
+- Remove compatibility helpers for older pydantic versions.
+- Remove obsolete pydantic model example which was not used anywhere.
+- Adjust serializability tests to account for changed behavior in v2.
+- Adjust optional/required field marker tests to account for changed behavior in v2.
+- Adjust field constraint tests to account for changed behavior in v2.
+- Adjust erdantic tests to exclude the erdantic version number which caused tests to fail upon erdantic update.
+
+Documentation
+~~~~~~~~~~~~~
+
+- Add FAQ section regarding migration guide from v1 to v2.
+- Remove ``complete`` showcase from user's example.
+- Update READMEs with newest features and version specifiers.
+- Update developer's setup section to address v1 to v2 changes.
+- Updates user's installation section to address v1 to v2 changes.
+- Remove all obsolete documentation on removed config documenters.
+- Rename all occurences to v2 ``field_validator`` and ``model_validator``.
+
+Contributors
+~~~~~~~~~~~~
+
+- Special thanks to `awoimbee <https://github.com/awoimbee>`__ for providing
+  a draft for the v1 to v2 migration which really initiated the work on
+  supporting pydantic v2
+  `#160 <https://github.com/mansenfranzen/autodoc_pydantic/pull/160>`__.
+- Many thanks to `PriOliveira <https://github.com/PriOliveira>`__ for reviewing
+  changes required for the v1 to v2 release
+  `#160 <https://github.com/mansenfranzen/autodoc_pydantic/pull/160>`__.
 
 
 v1.9.0 - 2023-06-08

--- a/docs/source/developers/setup.rst
+++ b/docs/source/developers/setup.rst
@@ -37,7 +37,7 @@ Creating environment
 
 .. code-block:: bash
 
-   poetry install -E dev
+   poetry install -E dev -E erdantic
 
 -----------------------
 Running & writing tests

--- a/docs/source/developers/setup.rst
+++ b/docs/source/developers/setup.rst
@@ -1,3 +1,6 @@
+.. _main-1.x: https://github.com/mansenfranzen/autodoc_pydantic/tree/main-1.x
+.. _main: https://github.com/mansenfranzen/autodoc_pydantic/tree/main
+
 =====
 Setup
 =====
@@ -19,15 +22,15 @@ Cloning repository
 
 .. note::
 
-   In June 2023, pydantic v2 was released. This introduced backwards
+   In June 2023, **pydantic v2** was released. This introduced backwards
    incompatible API and behavioral changes in comparison to pydantic v1. Hence,
    **autodoc_pydantic** required substantial adjustments, too. In order to keep
-   the codebase clean and concise, separate version for v1 and v2 were created.
-   The v2 branch will eventually become the new `main <asd>`_ branch while the
-   code for v1 resides in the `main-1.x <asd>`_ branch.
+   the codebase clean and concise, separate versions for v1 and v2 were
+   created. The v2 branch will eventually become the new `main`_ branch while
+   the code for v1 remains in the `main-1.x`_ branch.
 
    In a nutshell, if you want to work on v1, please checkout the corresponding
-   `main-1.x <asd>`_ branch.
+   `main-1.x`_ branch. Otherwise, refer to the `main`_ branch.
 
 Creating environment
 --------------------
@@ -75,7 +78,7 @@ Please visit the ``tox.ini`` for all available test environments.
 Building & writing docs
 -----------------------
 
-**autodoc_pydantic**'s documentation is generated with `sphinx <https://www.sphinx-doc.org>`__.
+**autodoc_pydantic**'s documentation is generated with `sphinx <https://www.sphinx-doc.org>`_ .
 To generate the HTML documentation, please use the following:
 
 .. code-block:: bash

--- a/docs/source/developers/setup.rst
+++ b/docs/source/developers/setup.rst
@@ -17,6 +17,18 @@ Cloning repository
    git clone https://github.com/mansenfranzen/autodoc_pydantic.git
    cd autodoc_pydantic
 
+.. note::
+
+   In June 2023, pydantic v2 was released. This introduced backwards
+   incompatible API and behavioral changes in comparison to pydantic v1. Hence,
+   **autodoc_pydantic** required substantial adjustments, too. In order to keep
+   the codebase clean and concise, separate version for v1 and v2 were created.
+   The v2 branch will eventually become the new `main <asd>`_ branch while the
+   code for v1 resides in the `main-1.x <asd>`_ branch.
+
+   In a nutshell, if you want to work on v1, please checkout the corresponding
+   `main-1.x <asd>`_ branch.
+
 Creating environment
 --------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Features
 - 📋 shows summary section for model configuration, fields and validators
 - 👀 hides overloaded and redundant model class signature
 - 🔱 visualizes entity-relationship-diagrams for class hierarchies
-- 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 3.5.0`
+- 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 4.0.0`
 
 To see those features in action, jump over to the :ref:`example <showcase>` section comparing
 the appearance of standard sphinx autodoc with **autodoc_pydantic**.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,7 +86,7 @@ and all `contributors <https://github.com/mansenfranzen/autodoc_pydantic/tree/re
 .. |DownloadsBadge| image:: https://img.shields.io/pypi/dm/autodoc_pydantic?color=fe7d37&style=flat
 .. _DownloadsBadge: https://pypistats.org/packages/autodoc-pydantic
 
-.. |ContributersBadge| image:: https://img.shields.io/badge/all_contributors-31-orange.svg?style=flat
+.. |ContributersBadge| image:: https://img.shields.io/badge/all_contributors-35-orange.svg?style=flat
 .. _ContributersBadge: https://github.com/mansenfranzen/autodoc_pydantic/tree/refactor_inspection#acknowledgements
 
 .. |CoverageBadge| image:: https://img.shields.io/codecov/c/gh/mansenfranzen/autodoc_pydantic?style=flat

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,14 @@ Perfect, let's go. But wait, sphinx' `autodoc <https://www.sphinx-doc.org/en/mas
 does not integrate too well with pydantic models 😕.
 Don't worry - just :code:`pip install autodoc_pydantic` 😉.
 
+.. note::
+
+   This documentation is based on ``autodoc_pydantic >= 2.0.0``. If you are
+   using pydantic v1 along with ``autodoc_pydantic < 2.0.0``, please find the
+   latest v1 documentation `here <add_old_link_here>`_ .
+
+   For **migration** guidance from v1 to v2, please see `here <asd>`_ .
+
 Features
 --------
 
@@ -22,8 +30,8 @@ Features
 - 📎 defines explicit pydantic prefixes for models, settings, fields, validators and model config
 - 📋 shows summary section for model configuration, fields and validators
 - 👀 hides overloaded and redundant model class signature
-- 📚 sorts fields, validators and model config within models by type
-- 🍀 Supports `pydantic >= 1.5.0, <2.0.0` and `sphinx >= 3.4.0`
+- visualizes entity-relationship-diagrams for class hierarchies
+- 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 3.5.0`
 
 To see those features in action, jump over to the :ref:`example <showcase>` section comparing
 the appearance of standard sphinx autodoc with **autodoc_pydantic**.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,14 +12,6 @@ Perfect, let's go. But wait, sphinx' `autodoc <https://www.sphinx-doc.org/en/mas
 does not integrate too well with pydantic models 😕.
 Don't worry - just :code:`pip install autodoc_pydantic` 😉.
 
-.. note::
-
-   This documentation is based on ``autodoc_pydantic >= 2.0.0``. If you are
-   using pydantic v1 along with ``autodoc_pydantic < 2.0.0``, please find the
-   latest v1 documentation `here <add_old_link_here>`_ .
-
-   For **migration** guidance from v1 to v2, please see `here <asd>`_ .
-
 Features
 --------
 
@@ -30,11 +22,17 @@ Features
 - 📎 defines explicit pydantic prefixes for models, settings, fields, validators and model config
 - 📋 shows summary section for model configuration, fields and validators
 - 👀 hides overloaded and redundant model class signature
-- visualizes entity-relationship-diagrams for class hierarchies
+- 🔱 visualizes entity-relationship-diagrams for class hierarchies
 - 🍀 Supports `pydantic >= 1.5.0` and `sphinx >= 3.5.0`
 
 To see those features in action, jump over to the :ref:`example <showcase>` section comparing
 the appearance of standard sphinx autodoc with **autodoc_pydantic**.
+
+.. note::
+
+   This documentation is based on ``autodoc_pydantic >= 2.0.0``. If you are
+   using pydantic v1 along with ``autodoc_pydantic < 2.0.0``, please find the
+   latest v1 documentation `here <https://autodoc-pydantic.readthedocs.io/en/main-1.x/>`_ .
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/users/configuration.rst
+++ b/docs/source/users/configuration.rst
@@ -23,7 +23,7 @@ how pydantic objects are displayed:
 
       .. autopydantic_model:: module.Model
          :model-show-json: True
-         :model-show-config: False
+         :model-show-config-summary: False
 
 
 .. note::
@@ -47,21 +47,7 @@ Contains all modifications for pydantic `BaseModel`.
    :values: True, False
 
    Show model config summary within the class doc string. It may be meaningful
-   when the class configuration carries some relevant information and you don't
-   want to show the entire config class as an explicit member
-   (see :ref:`model-show-config-member <autodoc_pydantic_model_show_config_member>`).
-
-
-.. config_description:: autopydantic_model
-   :title: Show Config Member
-   :path: target.configuration.ModelShowConfigMember
-   :confpy: autodoc_pydantic_model_show_config_member
-   :directive_option: model-show-config-member
-   :enable: members
-   :values: True, False*
-
-   Show pydantic config class. It can be hidden if it is irrelevant or if
-   replaced with :ref:`model-show-config-summary <autodoc_pydantic_model_show_config_summary>`.
+   when the class configuration carries some relevant information.
 
 
 .. config_description:: autopydantic_model
@@ -277,21 +263,7 @@ Contains all modifications for pydantic `BaseSettings`.
    :values: True, False
 
    Show model config summary within the class doc string. It may be meaningful
-   when the class configuration carries some relevant information and you don't
-   want to show the entire config class as an explicit member
-   (see :ref:`settings-show-config-member <autodoc_pydantic_settings_show_config_member>`).
-
-
-.. config_description:: autopydantic_settings
-   :title: Show Config Member
-   :path: target.configuration.SettingsShowConfigMember
-   :confpy: autodoc_pydantic_settings_show_config_member
-   :directive_option: settings-show-config-member
-   :enable: members
-   :values: True, False*
-
-   Show pydantic config class. It can be hidden if it is irrelevant or if
-   replaced with :ref:`settings-show-config-summary <autodoc_pydantic_settings_show_config_summary>`.
+   when the class configuration carries some relevant information.
 
 
 .. config_description:: autopydantic_settings

--- a/docs/source/users/examples.rst
+++ b/docs/source/users/examples.rst
@@ -43,38 +43,6 @@ In contrast, it also shows how standard sphinx autodoc displays the same example
          .. autopydantic_settings:: target.example_setting.ExampleSettings
 
 
---------
-Complete
---------
-
-This example represents a rendered output for which all features are enabled.
-It deviates from the default configuration above because it contains redundant
-information which is most likely not required. However, for demonstration purposes,
-this scenario covers all available display options for pydantic models/settings.
-
-
-.. tabs::
-
-   .. tab:: *rendered output*
-
-      .. autopydantic_settings:: target.example_setting.ExampleSettings
-         :noindex:
-         :settings-show-config-member: True
-         :validator-list-fields: True
-
-   .. tab:: reST
-
-      .. code-block::
-
-         .. autopydantic_settings:: target.example_setting.ExampleSettings
-            :noindex:
-            :settings-show-config-member: True
-            :validator-list-fields: True
-
-   .. tab:: python
-
-      .. autocodeblock:: target.example_setting
-
 ----------------------------
 Entity-Relationship Diagram
 ----------------------------

--- a/docs/source/users/examples.rst
+++ b/docs/source/users/examples.rst
@@ -29,7 +29,7 @@ In contrast, it also shows how standard sphinx autodoc displays the same example
       .. autopydantic_settings:: target.example_setting.ExampleSettings
          :members:
          :undoc-members:
-         :__doc_disable_except__: members, undoc-members, settings-show-validator-members, settings-show-config-member, config-members
+         :__doc_disable_except__: members, undoc-members, settings-show-validator-members
          :noindex:
 
    .. tab:: python
@@ -86,7 +86,6 @@ and model/setting config is hidden.
       .. autopydantic_settings:: target.example_setting.ExampleSettings
          :noindex:
          :settings-show-json: False
-         :settings-show-config-member: False
          :settings-show-config-summary: False
          :settings-show-validator-members: False
          :settings-show-validator-summary: False
@@ -99,7 +98,6 @@ and model/setting config is hidden.
 
          .. autopydantic_settings:: target.example_setting.ExampleSettings
             :settings-show-json: False
-            :settings-show-config-member: False
             :settings-show-config-summary: False
             :settings-show-validator-members: False
             :settings-show-validator-summary: False
@@ -114,16 +112,16 @@ Specifics
 =========
 
 This section focuses rendered documentation examples of pydantic specific
-concepts such as root validators, required/optional fields or generic models.
+concepts such as model validators, required/optional fields or generic models.
 
-----------------------------
-Asterisk and root validators
-----------------------------
+----------------
+Model validators
+----------------
 
-This example highlights how `asterisk <https://pydantic-docs.helpmanual.io/usage/validators/#pre-and-per-item-validators>`_
-(``@field_validator('*')``) and `root validators <https://pydantic-docs.helpmanual.io/usage/validators/#root-validators>`_ (``@root_validator``)
-are represented. Since they validate all fields, their corresponding field reference is replaced
-with a simple ``all fields`` marker which hyperlinks to the related model itself.
+This example highlights how ``model validators <https://docs.pydantic.dev/latest/usage/validators/#model-validators>`_
+(``@model_validator`` or ``@field_validator('*')``) are represented. Since they
+validate all fields, their corresponding field reference is replaced with a
+simple ``all fields`` marker which hyperlinks to the related model itself.
 
 .. tabs::
 

--- a/docs/source/users/faq.rst
+++ b/docs/source/users/faq.rst
@@ -20,9 +20,8 @@ of **autodoc_pydantic** (v1.9.0 -> v2.0.0), too.
 Do I need to migrate existing sphinx code?
 ------------------------------------------
 
-Maybe under rare circumstances 😋: **autodoc_pydantic**'s API remained stable,
-however a redundant and rather exotic feature was removed to reduce complexity
-and maintenance efforts.
+Maybe 😋. **autodoc_pydantic**'s API remained stable, execpt for removing a
+redundant and rather exotic feature.
 
 Specifically, the following global ``conf.py`` configurations and their
 corresponding local directive options are no longer available:

--- a/docs/source/users/faq.rst
+++ b/docs/source/users/faq.rst
@@ -20,9 +20,9 @@ of **autodoc_pydantic** (v1.9.0 -> v2.0.0), too.
 Do I need to migrate existing sphinx code?
 ------------------------------------------
 
-Luckily, this will not be mandatory in most of the case. **autodoc_pydantic**'s
-API remained stable, however a redundant and rather exotic feature was removed
-to reduce complexity and maintenance efforts.
+Maybe under rare circumstances 😋: **autodoc_pydantic**'s API remained stable,
+however a redundant and rather exotic feature was removed to reduce complexity
+and maintenance efforts.
 
 Specifically, the following global ``conf.py`` configurations and their
 corresponding local directive options are no longer available:

--- a/docs/source/users/faq.rst
+++ b/docs/source/users/faq.rst
@@ -5,6 +5,43 @@
 FAQ
 ===
 
+Migration guide from v1 to v2
+=============================
+
+In June 2023, pydantic v2 was released while introducing backwards incompatible
+API and behavioral changes in comparison to pydantic v1. Supporting pydantic v2
+required substantial adjustments to the codebase leading to a new major release
+of **autodoc_pydantic** (v1.9.0 -> v2.0.0), too.
+
+Do I need to migrate existing sphinx code?
+------------------------------------------
+
+Luckily, this will not be mandatory in most of the case. **autodoc_pydantic**'s
+API remained stable, however a redundant and rather exotic feature was removed
+to reduce complexity and maintenance efforts.
+
+Specifically, the following global ``conf.py`` configurations and their
+corresponding local directive options are no longer available:
+
+- ``autodoc_pydantic_model_show_config_member``
+- ``autodoc_pydantic_settings_show_config_member``
+- ``autodoc_pydantic_config_members``
+- ``autodoc_pydantic_config_signature_prefix``
+
+These enabled documenting pydantic model configurations in isolation or as a
+separate member of the pydantic model (see `here <asd>`_ ). However, they are
+redundant and less concise in regard to
+``autodoc_pydantic_model_show_config_summary`` and
+``autodoc_pydantic_settings_show_config_summary``. Please use these instead
+in order to document your model configurations.
+
+Are pydantic's v2 semantic changes preserved?
+---------------------------------------------
+
+**autodoc_pydantic** does not modify the underlying behavior of pydantic in
+any way. Instead, it only documents whatever pydantic exposes. Hence, all
+behavioral changes such as the new default strict mode are preserved.
+
 Show inherited fields/validators
 ================================
 

--- a/docs/source/users/faq.rst
+++ b/docs/source/users/faq.rst
@@ -1,9 +1,13 @@
 .. _sphinx.ext.autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 .. _autoapi: https://sphinx-autoapi.readthedocs.io/en/latest/index.html
+.. _config-class: https://autodoc-pydantic.readthedocs.io/en/main-1.x/users/configuration.html#config-class
+.. _show-config-member: https://autodoc-pydantic.readthedocs.io/en/main-1.x/users/configuration.html#show-config-member
 
 ===
 FAQ
 ===
+
+.. _faq_migration_guide:
 
 Migration guide from v1 to v2
 =============================
@@ -29,18 +33,18 @@ corresponding local directive options are no longer available:
 - ``autodoc_pydantic_config_signature_prefix``
 
 These enabled documenting pydantic model configurations in isolation or as a
-separate member of the pydantic model (see `here <asd>`_ ). However, they are
-redundant and less concise in regard to
-``autodoc_pydantic_model_show_config_summary`` and
+separate member of the pydantic model (see `config-class`_ and
+`show-config-member`_). However, they are redundant and less concise in
+contrast to ``autodoc_pydantic_model_show_config_summary`` and
 ``autodoc_pydantic_settings_show_config_summary``. Please use these instead
 in order to document your model configurations.
 
-Are pydantic's v2 semantic changes preserved?
----------------------------------------------
+Does autodoc_pydantic modify pydantic's v2 semantics?
+-----------------------------------------------------
 
-**autodoc_pydantic** does not modify the underlying behavior of pydantic in
+No, **autodoc_pydantic** does not modify the underlying behavior of pydantic in
 any way. Instead, it only documents whatever pydantic exposes. Hence, all
-behavioral changes such as the new default strict mode are preserved.
+behavioral changes such as the new default strict mode are preserved in v2.
 
 Show inherited fields/validators
 ================================

--- a/docs/source/users/installation.rst
+++ b/docs/source/users/installation.rst
@@ -3,7 +3,22 @@ Installation
 ============
 
 **autodoc_pydantic** is a sphinx extension and works well with
-:code:`pydantic >= 1.5.0` and :code:`sphinx >= 3.4.0`.
+:code:`pydantic >= 1.5.0` and :code:`sphinx >= 3.5.0`.
+
+.. note::
+
+   In June 2023, pydantic v2 was released. This introduced backwards
+   incompatible API and behavioral semantic changes in comparison to pydantic
+   v1. Hence, **autodoc_pydantic** required substantial changes, too. In order
+   to keep the codebase clean and concise, a separate branch for v2 was created
+   while the original code remains in the v1 branch.
+
+   In a nutshell, support for pydantic v2 is provided via
+   ``autodoc_pydantic >= 2.0.0`` whereas pydantic v1 will required
+   ``autodoc_pydantic < 2.0.0``. By default, your dependency resolver should
+   automatically select the correct version depending on the given pydantic
+   version.
+
 
 1. Install with pip
 ===================
@@ -16,8 +31,11 @@ into your documentation building environment:
    pip install autodoc_pydantic
 
 .. warning::
-   If you wish to use the :ref:`model-erdantic-figure <autodoc_pydantic_model_erdantic_figure>` option, you need to
-   first install `graphviz <https://graphviz.org/download/>`_, then install **autodoc_pydantic** with the erdantic option:
+   If you wish to use the
+   :ref:`model-erdantic-figure <autodoc_pydantic_model_erdantic_figure>`
+   feature to visualize ERD, you will need to install
+   `graphviz <https://graphviz.org/download/>`_ first, then install
+   **autodoc_pydantic** with the erdantic option:
 
    .. code-block:: bash
 

--- a/docs/source/users/installation.rst
+++ b/docs/source/users/installation.rst
@@ -7,17 +7,11 @@ Installation
 
 .. note::
 
-   In June 2023, pydantic v2 was released. This introduced backwards
-   incompatible API and behavioral semantic changes in comparison to pydantic
-   v1. Hence, **autodoc_pydantic** required substantial changes, too. In order
-   to keep the codebase clean and concise, a separate branch for v2 was created
-   while the original code remains in the v1 branch.
-
-   In a nutshell, support for pydantic v2 is provided via
-   ``autodoc_pydantic >= 2.0.0`` whereas pydantic v1 will required
-   ``autodoc_pydantic < 2.0.0``. By default, your dependency resolver should
-   automatically select the correct version depending on the given pydantic
-   version.
+   Pydantic v2 is supported by ``autodoc_pydantic >= 2.0.0`` while pydantic v1
+   remains functional via ``autodoc_pydantic < 2.0.0``. By default, your
+   dependency resolver will automatically select the correct
+   **autodoc_pydantic** version based on the given pydantic version. For more
+   information, please refer to the `FAQ <link here>`_ .
 
 
 1. Install with pip

--- a/docs/source/users/installation.rst
+++ b/docs/source/users/installation.rst
@@ -9,9 +9,12 @@ Installation
 
    Pydantic v2 is supported by ``autodoc_pydantic >= 2.0.0`` while pydantic v1
    remains functional via ``autodoc_pydantic < 2.0.0``. By default, your
-   dependency resolver will automatically select the correct
-   **autodoc_pydantic** version based on the given pydantic version. For more
-   information, please refer to the `FAQ <link here>`_ .
+   dependency resolver automatically selects the correct **autodoc_pydantic**
+   version based on the given pydantic version. However, it is best practice to
+   manually pin your dependency ranges accordingly.
+
+   For more information regarding the migration from v1 to v2, please refer to
+   the :ref:`FAQ <faq_migration_guide>`.
 
 
 1. Install with pip

--- a/docs/source/users/usage.rst
+++ b/docs/source/users/usage.rst
@@ -103,7 +103,7 @@ autopydantic
 ============
 
 You may want to document pydantic objects explicitly. This is possible via the
-specialized directives provided by *autodoc_pydantic*:
+specialized directives provided by **autodoc_pydantic**:
 
 - :ref:`autopydantic_model`
 - :ref:`autopydantic_settings`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ Sphinx = ">=4.0"
 pydantic = ">=2.0,<3.0.0"
 pydantic-settings = ">=2.0,<3.0.0"
 
+importlib-metadata = { version = "^6.8", markers = "python_version <= '3.8'" }
+
 sphinx-rtd-theme = { version = "^1.0", optional = true }
 sphinx-tabs = { version = "^3", optional = true }
 sphinx-copybutton = { version = "^0.4", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ Sphinx = ">=4.0"
 pydantic = ">=2.0,<3.0.0"
 pydantic-settings = ">=2.0,<3.0.0"
 
-importlib-metadata = { version = "^6.8", markers = "python_version <= '3.8'" }
+importlib-metadata = { version = ">1", markers = "python_version <= '3.8'" }
 
 sphinx-rtd-theme = { version = "^1.0", optional = true }
 sphinx-tabs = { version = "^3", optional = true }

--- a/sphinxcontrib/autodoc_pydantic/__init__.py
+++ b/sphinxcontrib/autodoc_pydantic/__init__.py
@@ -4,7 +4,11 @@
 
 from pathlib import Path
 from typing import Dict, Any
-from importlib.metadata import version
+
+try:
+    from importlib.metadata import version
+except ModuleNotFoundError:
+    from importlib_metadata import version
 
 from sphinx.domains import ObjType
 from sphinx.application import Sphinx

--- a/sphinxcontrib/autodoc_pydantic/__init__.py
+++ b/sphinxcontrib/autodoc_pydantic/__init__.py
@@ -78,7 +78,6 @@ def add_configuration_values(app: Sphinx):
 
     add(f'{stem}settings_show_json', True, True, bool)
     add(f'{stem}settings_show_json_error_strategy', json_strategy, True, str)
-    add(f'{stem}settings_show_config_member', False, True, bool)
     add(f'{stem}settings_show_config_summary', True, True, bool)
     add(f'{stem}settings_show_validator_members', True, True, bool)
     add(f'{stem}settings_show_validator_summary', True, True, bool)
@@ -93,7 +92,6 @@ def add_configuration_values(app: Sphinx):
 
     add(f'{stem}model_show_json', True, True, bool)
     add(f'{stem}model_show_json_error_strategy', json_strategy, True, str)
-    add(f'{stem}model_show_config_member', False, True, bool)
     add(f'{stem}model_show_config_summary', True, True, bool)
     add(f'{stem}model_show_validator_members', True, True, bool)
     add(f'{stem}model_show_validator_summary', True, True, bool)

--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -38,7 +38,8 @@ from sphinxcontrib.autodoc_pydantic.inspection import ModelInspector, \
 from sphinxcontrib.autodoc_pydantic.directives.options.composites import (
     AutoDocOptions
 )
-from sphinxcontrib.autodoc_pydantic.directives.utility import NONE
+from sphinxcontrib.autodoc_pydantic.directives.utility import NONE, \
+    intercept_type_annotations_py_gt_39
 
 try:
     import erdantic as erd
@@ -337,11 +338,12 @@ class PydanticModelDocumenter(ClassDocumenter):
         """
         source_name = self.get_sourcename()
         if erd is None:
-            error_msg = 'erdantic is not installed, you need to install ' \
-                'it before creating an Entity Relationship Diagram for ' \
-                'f{self.fullname}. See ' \
-                'https://autodoc-pydantic.readthedocs.io/' \
-                'en/stable/users/installation.html'
+            error_msg = (
+                'erdantic is not installed, you need to install it before '
+                'creating an Entity Relationship Diagram for '
+                'f{self.fullname}. See '
+                'https://autodoc-pydantic.readthedocs.io/'
+                'en/stable/users/installation.html')
             raise RuntimeError(error_msg)
 
         # Graphviz [DOT language](https://graphviz.org/doc/info/lang.html)
@@ -801,6 +803,15 @@ class PydanticFieldDocumenter(AttributeDocumenter):
             self.add_line(line, source_name)
 
         self.add_line("", source_name)
+
+    def add_line(self, line: str, source: str, *lineno: int) -> None:
+        """Intercept added rst lines to handle edge cases such as correct
+        string representation for annotated types in python < 3.9.
+
+        """
+
+        line = intercept_type_annotations_py_gt_39(line)
+        super().add_line(line, source, *lineno)
 
 
 class PydanticValidatorDocumenter(MethodDocumenter):

--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -39,6 +39,7 @@ from sphinxcontrib.autodoc_pydantic.directives.options.composites import (
     AutoDocOptions
 )
 from sphinxcontrib.autodoc_pydantic.directives.utility import NONE
+
 try:
     import erdantic as erd
 except ImportError:
@@ -896,4 +897,3 @@ class PydanticValidatorDocumenter(MethodDocumenter):
             self.add_line(line, source_name)
 
         self.add_line("", source_name)
-

--- a/sphinxcontrib/autodoc_pydantic/directives/utility.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/utility.py
@@ -10,8 +10,8 @@ from docutils.nodes import emphasis
 from sphinx.addnodes import pending_xref
 from sphinx.environment import BuildEnvironment
 
-
 REGEX_TYPE_ANNOT = re.compile(r"\s+:type:\s([a-zA-Z1-9]+)\[([a-zA-Z1-9]+)\]")
+
 
 class NullType:
     """Helper class to present a Null value which is not the same

--- a/sphinxcontrib/autodoc_pydantic/inspection.py
+++ b/sphinxcontrib/autodoc_pydantic/inspection.py
@@ -310,7 +310,9 @@ class ValidatorInspector(BaseInspectionComposite):
         return set(flattened)
 
     def get_reused_validators_names(self) -> List[str]:
-        """Identify all reused validators.
+        """Identify all reused validators. This is done implicitly by relying
+        on the fact the reused validators are registered as unbound functions
+        instead of bound methods.
 
         """
 
@@ -551,16 +553,14 @@ class ModelInspector:
         mapping = defaultdict(list)
         decorators = self.model.__pydantic_decorators__
 
-        # standard validators
+        # field validators
         for validator in decorators.field_validators.values():
             for field in validator.info.fields:
                 mapping[field].append(ValidatorAdapter(func=validator.func))
 
-        # root validators
+        # model validators
         for validator in decorators.model_validators.values():
-            is_pre = validator.info.mode == "before"
-            mapping["*"].append(ValidatorAdapter(func=validator.func,
-                                                 root_pre=is_pre))
+            mapping["*"].append(ValidatorAdapter(func=validator.func))
 
         return mapping
 

--- a/sphinxcontrib/autodoc_pydantic/inspection.py
+++ b/sphinxcontrib/autodoc_pydantic/inspection.py
@@ -376,6 +376,7 @@ class ConfigInspector(BaseInspectionComposite):
 
         return bool(self.items)
 
+
 class ReferenceInspector(BaseInspectionComposite):
     """Provide namespace for inspection methods for creating references
     mainly between pydantic fields and validators.

--- a/sphinxcontrib/autodoc_pydantic/inspection.py
+++ b/sphinxcontrib/autodoc_pydantic/inspection.py
@@ -20,18 +20,14 @@ from sphinx.addnodes import desc_signature
 ASTERISK_FIELD_NAME = "all fields"
 
 
-class ValidatorAdapter(BaseModel):
+class ValidatorAdapter(NamedTuple):
     """Provide standardized interface to pydantic's validator objects with
     additional metadata (e.g. root validator) for internal usage in
     autodoc_pydantic.
 
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     func: Callable
-    root_pre: bool = False
-    root_post: bool = False
 
     @property
     def name(self) -> str:

--- a/tests/compatibility.py
+++ b/tests/compatibility.py
@@ -20,16 +20,6 @@ def package_is_missing(package_name):
         return True
 
 
-def get_pydantic_version() -> Tuple:
-    """Helper function to get major and minor pydantic version.
-
-    """
-
-    version_strings = pydantic.version.VERSION.split(".")[:2]
-    version_numbers = [int(x) for x in version_strings]
-    return tuple(version_numbers)
-
-
 def desc_annotation_default_value(value: str):
     """Provides compatibility abstraction for `desc_annotation` for default
     values for sphinx version smaller and greater equal sphinx 4.3.
@@ -78,24 +68,6 @@ def rst_alias_class_directive() -> str:
     """
 
     return ":py:class:" if sphinx.version_info >= (4, 3) else ":class:"
-
-
-def object_is_serializable() -> bool:
-    """Provides compatibility abstraction to define whether type object is
-    serializable or not.
-
-    """
-
-    return get_pydantic_version() >= (1, 9)
-
-
-def requires_forward_ref() -> bool:
-    """Provides compatibility abstraction to define whether forward references
-    require `model.update_forward_refs()` in pydantic.
-
-    """
-
-    return get_pydantic_version() < (1, 9)
 
 
 def convert_ellipsis_to_none(result: List[str]) -> List[str]:

--- a/tests/roots/test-base/target/configuration.py
+++ b/tests/roots/test-base/target/configuration.py
@@ -1,7 +1,12 @@
-from typing import Optional, Annotated
+from typing import Optional
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 from pydantic import BaseModel, field_validator, Field, model_validator, \
-    ConfigDict, root_validator, conint, constr, Strict
+    ConfigDict, conint, constr, Strict
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -13,8 +13,6 @@ from pydantic import BaseModel, ConfigDict
 
 from sphinxcontrib.autodoc_pydantic.inspection import ModelInspector, \
     StaticInspector
-from tests.compatibility import object_is_serializable, requires_forward_ref, \
-    get_pydantic_version
 
 
 @pytest.fixture(scope="session")
@@ -54,9 +52,6 @@ def serializable_forward_ref():
         b: Foo = None
         c: "Foo" = None
 
-    if requires_forward_ref():
-        Foo.update_forward_refs()
-
     return ModelInspector(Foo)
 
 
@@ -69,9 +64,6 @@ def serializable_forward_ref_union():
         b: Union[Foo, int] = 2
         c: Union["Foo", str] = "foobar"
 
-    if requires_forward_ref():
-        Foo.update_forward_refs()
-
     return ModelInspector(Foo)
 
 
@@ -81,9 +73,6 @@ def serializable_self_reference():
         a: int = 123
         c: "Foo" = None
 
-    if requires_forward_ref():
-        Foo.update_forward_refs()
-
     return ModelInspector(Foo)
 
 
@@ -91,7 +80,7 @@ def serializable_self_reference():
     "field_test",
     [
         ("field_1", True),
-        ("field_2", object_is_serializable()),
+        ("field_2", True),
         ("field_3", True),
         ("field_4", False),
         ("field_5", True),


### PR DESCRIPTION
**Current docs build based on v2: [here](https://autodoc-pydantic.readthedocs.io/en/finalize_pydantic_v2/index.html)**

There is still some work to do until the release for v2. Following points have to be done:

- [x] Fix failing tests for python 3.7/3.8
- [x] Fix failing sphinx build test
- [x] Check entire documentation for pydantic v1 incompatibilities
  - [x] Remove obsolete config options from rst in examples
  - [x] Adjust to changed naming conventions like root validator -> model validator
- [x] Document changed behavior from v1 -> v2 regarding autodoc_pydantic
- [x] Update changelog
- [x] Remove compatibility layer from v1 versions in testing modules
- [x] Fix linting issues
- [ ] Provide release candidate for testing
- [x] Add new contributors

@awoimbee & @PriOliveira feel free to review or to provide any other code contributions.