### PR TITLE
Fix for issue 137 - cannot compare between <type> and None when sorting fields

### DIFF
--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -396,7 +396,7 @@ class PydanticModelDocumenter(ClassDocumenter):
         """
 
         all_validators = self.pydantic.inspect.validators.names
-        all_fields = self.pydantic.inspect.fields.names
+        all_fields = self._get_valid_fields()
         idx_validators = self._get_idx_mappings(all_validators)
         idx_fields = self._get_idx_mappings(all_fields)
 


### PR DESCRIPTION
Hello, 

I think I have a proposed fix to issue 137. However, I am having problems running the tox tests due to problems with erdantic. 
I have tried 
```
poetry run tox -e py310-pydanticlatest-sphinxlatest-no_erdantic
```
but it is still failing on trying to install erdantic and not finding include files for that. 

Please suggest workaround?