### PR TITLE
fix: Improve error message for `_sort_summary_list` failures

### DIFF
--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -569,15 +569,15 @@ class PydanticModelDocumenter(ClassDocumenter):
                 # catch cases where field is not found in tagorder
                 msg = f'Field {name} in {self.object_name} not found in tagorder'
                 raise ValueError(msg)
-        else:
-            msg = (
-                f'Invalid value `{sort_order}` provided for '
-                f'`summary_list_order`. Valid options are: '
-                f'{OptionsSummaryListOrder.values()}'
-            )
-            raise ValueError(msg)
 
-        return sorted(names, key=sort_func)
+        try:
+            return sorted(names, key=sort_func)
+        except TypeError as e:
+            msg = (
+                f'Uncaught exception while sorting fields for model'
+                f'{self.object_name} with sort order {sort_order}.'
+            )
+            raise ValueError(msg).with_traceback(e.__traceback__) from e
 
     def _get_field_summary_line(self, field_name: str) -> str:
         """Get reST for field summary for given `member_name`."""


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Enhanced error handling in `_sort_summary_list` to provide more informative error messages.
- The error message now includes the model name and sort order when a sorting exception occurs.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>autodocumenters.py</strong><dd><code>Enhanced Error Handling and Messaging in `_sort_summary_list`</code></dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
<li>Improved error handling in <code>_sort_summary_list</code> by adding a try-except <br>block.<br> <li> Enhanced the error message for exceptions during sorting, including <br>the model name and sort order.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/243/files#diff-7d73b320876bd66b008302d189d9a4550cfa334ade88a74e80a3405797e32192">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

