### PR TITLE
fix: Use more precise `name` instead of `object_name` for `_sort_summary_list` error msg

### DIFF
--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -575,7 +575,7 @@ class PydanticModelDocumenter(ClassDocumenter):
         except TypeError as e:
             msg = (
                 f'Uncaught exception while sorting fields for model'
-                f'{self.object_name} with sort order {sort_order}.'
+                f'{self.name} with sort order {sort_order}.'
             )
             raise ValueError(msg).with_traceback(e.__traceback__) from e
 

--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -574,7 +574,7 @@ class PydanticModelDocumenter(ClassDocumenter):
             return sorted(names, key=sort_func)
         except TypeError as e:
             msg = (
-                f'Uncaught exception while sorting fields for model'
+                f'Uncaught exception while sorting fields for model '
                 f'{self.name} with sort order {sort_order}.'
             )
             raise ValueError(msg).with_traceback(e.__traceback__) from e


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Updated the error message in `_sort_summary_list` method to use `self.name` instead of `self.object_name`, enhancing error clarity and precision.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>autodocumenters.py</strong><dd><code>Update Error Message for Precise Naming in `_sort_summary_list`</code></dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
<li>Updated the error message in <code>_sort_summary_list</code> to use <code>self.name</code> <br>instead of <code>self.object_name</code> for more precise error reporting.


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/244/files#diff-7d73b320876bd66b008302d189d9a4550cfa334ade88a74e80a3405797e32192">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

