### PR TITLE
chore: Add `internal`, `refactor` and more categories to release-please configuration.

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -38,6 +38,41 @@
             "type": "tests",
             "section": "🔧 Testing",
             "hidden": false
+        },
+        {
+            "type": "style",
+            "section": "💅 Code Style",
+            "hidden": false
+        },
+        {
+            "type": "refactor",
+            "section": "🔨 Refactoring",
+            "hidden": false
+        },
+        {
+            "type": "revert",
+            "section": "⏪ Reverts",
+            "hidden": false
+        },
+        {
+            "type": "internal",
+            "hidden": false,
+            "section": "🏠 Internal Changes"
+        },
+        {
+            "type": "deps",
+            "hidden": false,
+            "section": "⬆️ Dependency Updates"
+        },
+        {
+            "type": "security",
+            "hidden": false,
+            "section": "🔒 Security Fixes"
+        },
+        {
+            "type": "breaking",
+            "hidden": false,
+            "section": "💥 Breaking Changes"
         }
     ],
     "packages": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,11 +55,6 @@
             "hidden": false
         },
         {
-            "type": "internal",
-            "hidden": false,
-            "section": "🏠 Internal Changes"
-        },
-        {
             "type": "deps",
             "hidden": false,
             "section": "⬆️ Dependency Updates"
@@ -73,6 +68,11 @@
             "type": "breaking",
             "hidden": false,
             "section": "💥 Breaking Changes"
+        },
+        {
+            "type": "contributors",
+            "hidden": false,
+            "section": "👥 Contributors"
         }
     ],
     "packages": {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Expanded the `release-please-config.json` to include new categories for changelog generation.
- New categories include 'style', 'refactor', 'revert', 'internal', 'deps', 'security', and 'breaking'.
- Each new category is properly configured with a section name and visibility settings.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-please-config.json</strong><dd><code>Expand Release-Please Configuration with Additional Categories</code></dd></summary>
<hr>

release-please-config.json
<li>Added new categories for changelog generation: 'style', 'refactor', <br>'revert', 'internal', 'deps', 'security', 'breaking'.<br> <li> Each category is associated with a specific section and visibility <br>setting.


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/258/files#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2b">+35/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

