### PR TITLE
ci: Integrate `mypy` type checking

### DIFF
--- a/.github/actions/invoke-tox/action.yml
+++ b/.github/actions/invoke-tox/action.yml
@@ -42,7 +42,9 @@ runs:
       shell: bash
 
     - name: Invoke Tox
-      run: tox -e ${{ inputs.tox-environment }}
+      run: |
+        TOX_ENV_WITHOUT_DOTS=$(echo ${{ inputs.tox-environment }} | sed 's/\.//g')
+        tox -e $TOX_ENV_WITHOUT_DOTS
       shell: bash
 
     - name: Code Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,3 +123,14 @@ jobs:
         uses: ./.github/actions/invoke-tox
         with:
           tox-environment: formatter
+
+  type-checker:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Test Environment and Run Tox
+        uses: ./.github/actions/invoke-tox
+        with:
+          tox-environment: type-checker

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/actions/invoke-tox
         with:
           python-version: ${{ matrix.python_version }}
-          tox-environment: pydantic${{ matrix.pydantic_version }}-sphinx${{ matrix.sphinx_version }}
+          tox-environment: py${{ matrix.python_version }}-pydantic${{ matrix.pydantic_version }}-sphinx${{ matrix.sphinx_version }}
           install-graphviz: true
           codacy: ${{ secrets.CODACY_PROJECT_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,3 +134,4 @@ jobs:
         uses: ./.github/actions/invoke-tox
         with:
           tox-environment: type-checker
+          install-graphviz: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ myst-parser = {version = "^2.0", optional = true }
 pytest = {version = "^8.0.0", optional = true }
 coverage = { version ="^7", optional = true }
 
+# extras type checking
+mypy = { version  = "^1.9", optional = true }
+types-docutils = { version = "^0.20", optional = true }
+typing-extensions = { version = "^4.11", markers = "python_version <= '3.9'", optional = true }
+
 # extras linting/formatting
 ruff = { version = "^0.3", optional = true }
 
@@ -58,6 +63,10 @@ test = ["pytest",
         "coverage"]
 
 linting = ["ruff"]
+
+type_checking = ["mypy",
+                 "types-docutils",
+                 "typing-extensions"]
 
 erdantic = ["erdantic"]
 

--- a/sphinxcontrib/autodoc_pydantic/__init__.py
+++ b/sphinxcontrib/autodoc_pydantic/__init__.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 try:
     from importlib.metadata import version
 except ModuleNotFoundError:
     from importlib_metadata import version  # type: ignore[no-redef,import-not-found]
 
+from pydantic import BaseModel
 from sphinx.domains import ObjType
 
 from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
@@ -35,6 +36,88 @@ __version__ = version('autodoc_pydantic')
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
+
+
+PRE = 'autodoc_pydantic_'
+
+
+class AppConfig(BaseModel):
+    name: str
+    default: Any
+    types: type
+    rebuild: Literal['env'] = 'env'
+
+
+APP_CONFIGURATIONS = [
+    # settings
+    AppConfig(name=f'{PRE}settings_show_json', default=True, types=bool),
+    AppConfig(
+        name=f'{PRE}settings_show_json_error_strategy',
+        default=OptionsJsonErrorStrategy.WARN,
+        types=str,
+    ),
+    AppConfig(name=f'{PRE}settings_show_config_summary', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_show_validator_members', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_show_validator_summary', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_show_field_summary', default=True, types=bool),
+    AppConfig(
+        name=f'{PRE}settings_summary_list_order',
+        default=OptionsSummaryListOrder.ALPHABETICAL,
+        types=str,
+    ),
+    AppConfig(name=f'{PRE}settings_hide_paramlist', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_hide_reused_validator', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_undoc_members', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_members', default=True, types=bool),
+    AppConfig(name=f'{PRE}settings_member_order', default='groupwise', types=str),
+    AppConfig(
+        name=f'{PRE}settings_signature_prefix',
+        default='pydantic settings',
+        types=str,
+    ),
+    # model
+    AppConfig(name=f'{PRE}model_show_json', default=True, types=bool),
+    AppConfig(
+        name=f'{PRE}model_show_json_error_strategy',
+        default=OptionsJsonErrorStrategy.WARN,
+        types=str,
+    ),
+    AppConfig(name=f'{PRE}model_show_config_summary', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_show_validator_members', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_show_validator_summary', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_show_field_summary', default=True, types=bool),
+    AppConfig(
+        name=f'{PRE}model_summary_list_order',
+        default=OptionsSummaryListOrder.ALPHABETICAL,
+        types=str,
+    ),
+    AppConfig(name=f'{PRE}model_hide_paramlist', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_hide_reused_validator', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_undoc_members', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_members', default=True, types=bool),
+    AppConfig(name=f'{PRE}model_member_order', default='groupwise', types=str),
+    AppConfig(name=f'{PRE}model_signature_prefix', default='pydantic model', types=str),
+    AppConfig(name=f'{PRE}model_erdantic_figure', default=False, types=bool),
+    AppConfig(name=f'{PRE}model_erdantic_figure_collapsed', default=True, types=bool),
+    # validator
+    AppConfig(name=f'{PRE}validator_signature_prefix', default='validator', types=str),
+    AppConfig(name=f'{PRE}validator_replace_signature', default=True, types=bool),
+    AppConfig(name=f'{PRE}validator_list_fields', default=False, types=bool),
+    # field
+    AppConfig(name=f'{PRE}field_list_validators', default=True, types=bool),
+    AppConfig(
+        name=f'{PRE}field_doc_policy', default=OptionsFieldDocPolicy.BOTH, types=str
+    ),
+    AppConfig(name=f'{PRE}field_show_constraints', default=True, types=bool),
+    AppConfig(name=f'{PRE}field_show_alias', default=True, types=bool),
+    AppConfig(name=f'{PRE}field_show_default', default=True, types=bool),
+    AppConfig(name=f'{PRE}field_show_required', default=True, types=bool),
+    AppConfig(name=f'{PRE}field_show_optional', default=True, types=bool),
+    AppConfig(name=f'{PRE}field_swap_name_and_alias', default=False, types=bool),
+    AppConfig(name=f'{PRE}field_signature_prefix', default='field', types=str),
+    # general
+    AppConfig(name=f'{PRE}add_fallback_css_class', default=True, types=bool),
+]
 
 
 def add_css_file(app: Sphinx, *_) -> None:  # noqa: ANN002
@@ -71,57 +154,13 @@ def add_domain_object_types(app: Sphinx) -> None:
 def add_configuration_values(app: Sphinx) -> None:
     """Adds all configuration values to sphinx application."""
 
-    stem = 'autodoc_pydantic_'
-    add = app.add_config_value
-    json_strategy = OptionsJsonErrorStrategy.WARN
-    summary_list_order = OptionsSummaryListOrder.ALPHABETICAL
-
-    # ruff: noqa: FBT003
-    add(f'{stem}settings_show_json', True, True, bool)
-    add(f'{stem}settings_show_json_error_strategy', json_strategy, True, str)
-    add(f'{stem}settings_show_config_summary', True, True, bool)
-    add(f'{stem}settings_show_validator_members', True, True, bool)
-    add(f'{stem}settings_show_validator_summary', True, True, bool)
-    add(f'{stem}settings_show_field_summary', True, True, bool)
-    add(f'{stem}settings_summary_list_order', summary_list_order, True, str)
-    add(f'{stem}settings_hide_paramlist', True, True, bool)
-    add(f'{stem}settings_hide_reused_validator', True, True, bool)
-    add(f'{stem}settings_undoc_members', True, True, bool)
-    add(f'{stem}settings_members', True, True, bool)
-    add(f'{stem}settings_member_order', 'groupwise', True, str)
-    add(f'{stem}settings_signature_prefix', 'pydantic settings', True, str)
-
-    add(f'{stem}model_show_json', True, True, bool)
-    add(f'{stem}model_show_json_error_strategy', json_strategy, True, str)
-    add(f'{stem}model_show_config_summary', True, True, bool)
-    add(f'{stem}model_show_validator_members', True, True, bool)
-    add(f'{stem}model_show_validator_summary', True, True, bool)
-    add(f'{stem}model_show_field_summary', True, True, bool)
-    add(f'{stem}model_summary_list_order', summary_list_order, True, str)
-    add(f'{stem}model_hide_paramlist', True, True, bool)
-    add(f'{stem}model_hide_reused_validator', True, True, bool)
-    add(f'{stem}model_undoc_members', True, True, bool)
-    add(f'{stem}model_members', True, True, bool)
-    add(f'{stem}model_member_order', 'groupwise', True, str)
-    add(f'{stem}model_signature_prefix', 'pydantic model', True, str)
-    add(f'{stem}model_erdantic_figure', False, True, bool)
-    add(f'{stem}model_erdantic_figure_collapsed', True, True, bool)
-
-    add(f'{stem}validator_signature_prefix', 'validator', True, str)
-    add(f'{stem}validator_replace_signature', True, True, bool)
-    add(f'{stem}validator_list_fields', False, True, bool)
-
-    add(f'{stem}field_list_validators', True, True, bool)
-    add(f'{stem}field_doc_policy', OptionsFieldDocPolicy.BOTH, True, str)
-    add(f'{stem}field_show_constraints', True, True, bool)
-    add(f'{stem}field_show_alias', True, True, bool)
-    add(f'{stem}field_show_default', True, True, bool)
-    add(f'{stem}field_show_required', True, True, bool)
-    add(f'{stem}field_show_optional', True, True, bool)
-    add(f'{stem}field_swap_name_and_alias', False, True, bool)
-    add(f'{stem}field_signature_prefix', 'field', True, str)
-
-    add(f'{stem}add_fallback_css_class', True, True, bool)
+    for config in APP_CONFIGURATIONS:
+        app.add_config_value(
+            name=config.name,
+            default=config.default,
+            types=config.types,
+            rebuild=config.rebuild,
+        )
 
 
 def add_directives_and_autodocumenters(app: Sphinx) -> None:

--- a/sphinxcontrib/autodoc_pydantic/__init__.py
+++ b/sphinxcontrib/autodoc_pydantic/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 try:
     from importlib.metadata import version
 except ModuleNotFoundError:
-    from importlib_metadata import version
+    from importlib_metadata import version  # type: ignore[no-redef,import-not-found]
 
 from sphinx.domains import ObjType
 

--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable
 
 import sphinx
 from pydantic import BaseModel
@@ -547,6 +547,9 @@ class PydanticModelDocumenter(ClassDocumenter):
     def _get_tagorder(self, name: str) -> int | None:
         """Get tagorder for given `name`."""
 
+        if self.analyzer is None:
+            return None
+
         if name in self.analyzer.tagorder:
             return self.analyzer.tagorder.get(name)
 
@@ -672,7 +675,7 @@ class PydanticFieldDocumenter(AttributeDocumenter):
     objtype = 'pydantic_field'
     directivetype = 'pydantic_field'
     priority = 10 + AttributeDocumenter.priority
-    option_spec: OptionSpec = dict(AttributeDocumenter.option_spec)  # noqa: RUF012
+    option_spec: ClassVar[OptionSpec] = dict(AttributeDocumenter.option_spec)
     option_spec.update(OPTIONS_FIELD)
     member_order = 0
 
@@ -907,7 +910,7 @@ class PydanticValidatorDocumenter(MethodDocumenter):
         )
         return is_val and is_validator
 
-    def format_args(self, **kwargs: Any) -> str | None:  # noqa: ANN401
+    def format_args(self, **kwargs: Any) -> str:  # noqa: ANN401
         """Return empty arguments if validator should be replaced."""
 
         if self.pydantic.options.is_true('validator-replace-signature'):

--- a/sphinxcontrib/autodoc_pydantic/directives/directives.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/directives.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Tuple
+from typing import TYPE_CHECKING, Tuple
 
 import sphinx
 from docutils.nodes import Node, Text
@@ -48,17 +48,17 @@ class PydanticDirectiveMixin:
 
         # account for changed signature in sphinx 4.3, see #62
         if sphinx.version_info < (4, 3):
-            return f'{value} ' # type: ignore[return-value]
+            return f'{value} '  # type: ignore[return-value]
 
         from sphinx.addnodes import desc_sig_space
-        return [Text(value), desc_sig_space()]
 
+        return [Text(value), desc_sig_space()]
 
 
 class PydanticModel(PydanticDirectiveMixin, PyClasslike):
     """Specialized directive for pydantic models."""
 
-    option_spec: OptionSpec = PyClasslike.option_spec.copy() # type: ignore[misc]
+    option_spec: OptionSpec = PyClasslike.option_spec.copy()  # type: ignore[misc]
     option_spec.update(
         {
             '__doc_disable_except__': option_list_like,
@@ -73,7 +73,7 @@ class PydanticModel(PydanticDirectiveMixin, PyClasslike):
 class PydanticSettings(PydanticDirectiveMixin, PyClasslike):
     """Specialized directive for pydantic settings."""
 
-    option_spec: OptionSpec = PyClasslike.option_spec.copy() # type: ignore[misc]
+    option_spec: OptionSpec = PyClasslike.option_spec.copy()  # type: ignore[misc]
     option_spec.update(
         {
             '__doc_disable_except__': option_list_like,
@@ -88,7 +88,7 @@ class PydanticSettings(PydanticDirectiveMixin, PyClasslike):
 class PydanticField(PydanticDirectiveMixin, PyAttribute):
     """Specialized directive for pydantic fields."""
 
-    option_spec: OptionSpec = PyAttribute.option_spec.copy() # type: ignore[misc]
+    option_spec: OptionSpec = PyAttribute.option_spec.copy()  # type: ignore[misc]
     option_spec.update(
         {
             'alias': unchanged,
@@ -149,9 +149,7 @@ class PydanticField(PydanticDirectiveMixin, PyAttribute):
 
         signode += desc_annotation('', f" ({prefix} '{value}')")
 
-    def _find_desc_name_node(
-        self, sig: str, signode: desc_signature
-    ) -> Node | None:
+    def _find_desc_name_node(self, sig: str, signode: desc_signature) -> Node | None:
         """Return `desc_name` node  from `signode` that contains the field
         name. This is used to replace the name with the alias.
 
@@ -209,7 +207,7 @@ class PydanticField(PydanticDirectiveMixin, PyAttribute):
 class PydanticValidator(PydanticDirectiveMixin, PyMethod):
     """Specialized directive for pydantic validators."""
 
-    option_spec: OptionSpec = PyMethod.option_spec.copy() # type: ignore[misc]
+    option_spec: OptionSpec = PyMethod.option_spec.copy()  # type: ignore[misc]
     option_spec.update(
         {
             'validator-replace-signature': option_default_true,

--- a/sphinxcontrib/autodoc_pydantic/directives/directives.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/directives.py
@@ -26,7 +26,7 @@ from sphinxcontrib.autodoc_pydantic.inspection import ModelInspector, ValidatorF
 TUPLE_STR = Tuple[str, str]
 
 
-class PydanticDirectiveBase:
+class PydanticDirectiveMixin:
     """Base class for pydantic directive providing common functionality."""
 
     config_name: str
@@ -52,7 +52,7 @@ class PydanticDirectiveBase:
         return f'{value} '
 
 
-class PydanticModel(PydanticDirectiveBase, PyClasslike):
+class PydanticModel(PydanticDirectiveMixin, PyClasslike):
     """Specialized directive for pydantic models."""
 
     option_spec = PyClasslike.option_spec.copy()
@@ -67,7 +67,7 @@ class PydanticModel(PydanticDirectiveBase, PyClasslike):
     default_prefix = 'class'
 
 
-class PydanticSettings(PydanticDirectiveBase, PyClasslike):
+class PydanticSettings(PydanticDirectiveMixin, PyClasslike):
     """Specialized directive for pydantic settings."""
 
     option_spec = PyClasslike.option_spec.copy()
@@ -82,7 +82,7 @@ class PydanticSettings(PydanticDirectiveBase, PyClasslike):
     default_prefix = 'class'
 
 
-class PydanticField(PydanticDirectiveBase, PyAttribute):
+class PydanticField(PydanticDirectiveMixin, PyAttribute):
     """Specialized directive for pydantic fields."""
 
     option_spec = PyAttribute.option_spec.copy()
@@ -199,7 +199,7 @@ class PydanticField(PydanticDirectiveBase, PyAttribute):
         return fullname, prefix
 
 
-class PydanticValidator(PydanticDirectiveBase, PyMethod):
+class PydanticValidator(PydanticDirectiveMixin, PyMethod):
     """Specialized directive for pydantic validators."""
 
     option_spec = PyMethod.option_spec.copy()

--- a/sphinxcontrib/autodoc_pydantic/directives/options/composites.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/options/composites.py
@@ -7,9 +7,9 @@ management of directive options.
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from sphinx.ext.autodoc import ALL, Documenter, Options
+from sphinx.ext.autodoc import ALL, Options
 
 from sphinxcontrib.autodoc_pydantic.directives.utility import NONE
 
@@ -30,7 +30,7 @@ class DirectiveOptions:
 
     """
 
-    def __init__(self, parent: Documenter | Any) -> None:  # noqa: ANN401
+    def __init__(self, parent: Any) -> None:  # noqa: ANN401
         self.parent = parent
         self.parent.options = Options(self.parent.options)
         self.add_default_options()
@@ -284,7 +284,8 @@ class AutoDocOptions(DirectiveOptions):
 
             return result
 
-        self.parent.add_directive_header = wrapped
+        # see https://github.com/python/mypy/issues/2427
+        self.parent.add_directive_header = wrapped  # type: ignore[method-assign]
 
     def pass_option_to_directive(self, name: str) -> None:
         """Pass an autodoc option through to the generated directive."""

--- a/sphinxcontrib/autodoc_pydantic/directives/options/composites.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/options/composites.py
@@ -13,9 +13,6 @@ from sphinx.ext.autodoc import ALL, Documenter, Options
 
 from sphinxcontrib.autodoc_pydantic.directives.utility import NONE
 
-if TYPE_CHECKING:
-    from docutils.parsers.rst import Directive
-
 
 class DirectiveOptions:
     """Composite class providing methods to manage getting and setting
@@ -33,7 +30,7 @@ class DirectiveOptions:
 
     """
 
-    def __init__(self, parent: Documenter | Directive) -> None:
+    def __init__(self, parent: Documenter | Any) -> None:  # noqa: ANN401
         self.parent = parent
         self.parent.options = Options(self.parent.options)
         self.add_default_options()
@@ -45,8 +42,7 @@ class DirectiveOptions:
         for option in options:
             self.set_default_option(option)
 
-    @staticmethod
-    def determine_app_cfg_name(name: str) -> str:
+    def determine_app_cfg_name(self, name: str) -> str:
         """Provide full app environment configuration name for given option
         name while converting "-" to "_".
 

--- a/sphinxcontrib/autodoc_pydantic/directives/options/definition.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/options/definition.py
@@ -1,5 +1,9 @@
 """This module contains the autodocumenter's option definitions."""
 
+from __future__ import annotations
+
+from typing import Callable
+
 from docutils.parsers.rst.directives import unchanged
 
 from sphinxcontrib.autodoc_pydantic.directives.options.enums import (
@@ -14,7 +18,7 @@ from sphinxcontrib.autodoc_pydantic.directives.options.validators import (
     option_one_of_factory,
 )
 
-OPTIONS_FIELD = {
+OPTIONS_FIELD: dict[str, Callable] = {
     'field-show-default': option_default_true,
     'field-show-required': option_default_true,
     'field-show-optional': option_default_true,
@@ -28,7 +32,7 @@ OPTIONS_FIELD = {
 }
 """Represents added directive options for :class:`PydanticFieldDocumenter`."""
 
-OPTIONS_VALIDATOR = {
+OPTIONS_VALIDATOR: dict[str, Callable] = {
     'validator-replace-signature': option_default_true,
     'validator-list-fields': option_default_true,
     'validator-signature-prefix': unchanged,
@@ -38,9 +42,9 @@ OPTIONS_VALIDATOR = {
 """Represents added directive options for :class:`PydanticValidatorDocumenter`.
 """
 
-OPTIONS_MERGED = {**OPTIONS_FIELD, **OPTIONS_VALIDATOR}
+OPTIONS_MERGED: dict[str, Callable] = {**OPTIONS_FIELD, **OPTIONS_VALIDATOR}
 
-OPTIONS_MODEL = {
+OPTIONS_MODEL: dict[str, Callable] = {
     'model-show-json': option_default_true,
     'model-show-json-error-strategy': option_one_of_factory(
         OptionsJsonErrorStrategy.values(),
@@ -64,7 +68,7 @@ OPTIONS_MODEL = {
 }
 """Represents added directive options for :class:`PydanticModelDocumenter`."""
 
-OPTIONS_SETTINGS = {
+OPTIONS_SETTINGS: dict[str, Callable] = {
     'settings-show-json': option_default_true,
     'settings-show-json-error-strategy': option_one_of_factory(
         OptionsJsonErrorStrategy.values(),

--- a/sphinxcontrib/autodoc_pydantic/directives/templates.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/templates.py
@@ -31,10 +31,10 @@ def to_collapsable(lines: list[str], title: str, css_class: str) -> list[str]:
 
     """
 
-    lines = '\n'.join(lines)
-    lines = TPL_COLLAPSE.format(
-        lines=lines,
+    lines_joined = '\n'.join(lines)
+    lines_formatted = TPL_COLLAPSE.format(
+        lines=lines_joined,
         summary=title,
         details_class=css_class,
     )
-    return lines.split('\n')
+    return lines_formatted.split('\n')

--- a/sphinxcontrib/autodoc_pydantic/inspection.py
+++ b/sphinxcontrib/autodoc_pydantic/inspection.py
@@ -11,7 +11,12 @@ import itertools
 import pydoc
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeGuard, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeVar
+
+try:
+    from typing import TypeGuard
+except ImportError:
+    from typing_extensions import TypeGuard
 
 from pydantic import BaseModel, ConfigDict, PydanticInvalidForJsonSchema, create_model
 from pydantic_settings import BaseSettings

--- a/tox.ini
+++ b/tox.ini
@@ -71,13 +71,22 @@ deps =
     git+https://github.com/drivendataorg/erdantic.git
 
 [testenv:linter]
+description = "Run linters on the codebase."
 skip_sdist = true
 skip_install = true
 deps = ruff
 commands = ruff check sphinxcontrib
 
 [testenv:formatter]
+description = "Check correct formatting of the codebase."
 skip_sdist = true
 skip_install = true
 deps = ruff
 commands = ruff format --diff
+
+[testenv:type-checker]
+description = "Type check the codebase."
+extras = 
+    type_checking
+    erdantic
+commands = mypy sphinxcontrib/ --explicit-package-bases

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     coverage report -m
     coverage xml
 
-[testenv:pydantic{20,21,22,23,24,25,26,27,latest}-sphinx{40,45,53,62,70,71,72,latest}]
+[testenv:py{37,38,39,310,311,312}-pydantic{20,21,22,23,24,25,26,27,latest}-sphinx{40,45,53,62,70,71,72,latest}]
 description = "Test specific historical stable versions."
 deps =
     pydantic20: pydantic~=2.0.0


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new AppConfig class using Pydantic for streamlined configuration management in `sphinxcontrib/autodoc_pydantic/__init__.py`.
- Enhanced type safety and clarity across various methods in `autodocumenters.py`.
- Renamed PydanticDirectiveBase to PydanticDirectiveMixin and updated handling of signature prefixes in `directives.py`.
- Integrated mypy type checking in GitHub Actions and added a new tox environment for type checking.
- Added dependencies for mypy and related packages to facilitate type checking.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Refactor Configuration Management Using Pydantic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/__init__.py
<li>Introduced AppConfig class using Pydantic for configuration <br>management.<br> <li> Replaced manual configuration addition with a loop over a list of <br>AppConfig instances.<br> <li> Added type annotations and handled import adjustments for better type <br>checking.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/259/files#diff-2c45a425561c96ca298973fe90efaa556380339cf8b9643593dd10ead6abd1bd">+92/-53</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>autodocumenters.py</strong><dd><code>Enhance Type Safety and Clarity in Autodocumenters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
<li>Improved type annotations and error handling.<br> <li> Refactored method to add erdantic figure with better import handling.<br> <li> Enhanced clarity and type safety in various methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/259/files#diff-7d73b320876bd66b008302d189d9a4550cfa334ade88a74e80a3405797e32192">+45/-31</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>directives.py</strong><dd><code>Rename Base Directive Class and Update Method Implementations</code></dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/directives/directives.py
<li>Renamed PydanticDirectiveBase to PydanticDirectiveMixin for clarity.<br> <li> Updated method for handling signature prefixes to support different <br>Sphinx versions.<br> <li> Improved error handling and type annotations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/259/files#diff-e0cc3e8ad9ed96af5dd156785aebb4e3e70a42952442ae7b1667c7a374587b30">+29/-24</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.yml</strong><dd><code>Integrate Mypy Type Checking in GitHub Actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/tests.yml
<li>Added a new job for type checking using mypy.<br> <li> Adjusted tox environment naming to include Python version.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/259/files#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957f">+14/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Add Type Checking Environment and Update Existing Configurations</code></dd></summary>
<hr>

tox.ini
<li>Added a new test environment for type checking.<br> <li> Updated existing environments to specify Python versions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/259/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449">+11/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add Mypy and Related Dependencies for Type Checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml
- Added mypy and related packages under type checking extras.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/259/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

