### PR TITLE
ci: Support pydantic 2.7 and sphinx 7.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
             sphinx_version: "72"
           - python_version: "3.12"
             pydantic_version: "27"
-            sphinx_version: "72"
+            sphinx_version: "73"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ myst-parser = {version = "^2.0", optional = true }
 # extras tests
 pytest = {version = "^8.0.0", optional = true }
 coverage = { version ="^7", optional = true }
+defusedxml = { version = ">=0.7.1", optional = true }
 
 # extras type checking
 mypy = { version  = "^1.9", optional = true }
@@ -60,7 +61,8 @@ docs = ["sphinx-rtd-theme",
         "myst-parser"]
 
 test = ["pytest",
-        "coverage"]
+        "coverage",
+        "defusedxml"]
 
 linting = ["ruff"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-pydantic{20,21,22,23,24,25,26,27,latest}-sphinx{40,45,53,62,70,71,72,latest}, latest, development, no_erdantic, linter
+envlist = py{37,38,39,310,311,312}-pydantic{20,21,22,23,24,25,26,27,latest}-sphinx{40,45,53,62,70,71,72,73,latest}, latest, development, no_erdantic, linter
 isolated_build = True
 
 [testenv]
@@ -12,7 +12,7 @@ commands =
     coverage report -m
     coverage xml
 
-[testenv:py{37,38,39,310,311,312}-pydantic{20,21,22,23,24,25,26,27,latest}-sphinx{40,45,53,62,70,71,72,latest}]
+[testenv:py{37,38,39,310,311,312}-pydantic{20,21,22,23,24,25,26,27,latest}-sphinx{40,45,53,62,70,71,72,73,latest}]
 description = "Test specific historical stable versions."
 deps =
     pydantic20: pydantic~=2.0.0
@@ -46,6 +46,7 @@ deps =
     sphinx70: sphinx~=7.0.0
     sphinx71: sphinx~=7.1.0
     sphinx72: sphinx~=7.2.0
+    sphinx73: sphinx~=7.3.0
     sphinxlatest: sphinx
 
 [testenv:latest]


### PR DESCRIPTION
ci: Add `defusedxml` as optional test dependency which was previously implicitly included by other deps.