### PR TITLE
ci: Add explicit `pydantic_settings` versions to prevent unwanted pydantic version upgrades in CI matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,31 @@ commands =
 description = "Test specific historical stable versions."
 deps =
     pydantic20: pydantic~=2.0.0
+    pydantic20: pydantic_settings~=2.0.0
+
     pydantic21: pydantic~=2.1.0
+    pydantic21: pydantic_settings~=2.0.0
+
     pydantic22: pydantic~=2.2.0
+    pydantic22: pydantic_settings~=2.0.0
+
     pydantic23: pydantic~=2.3.0
+    pydantic23: pydantic_settings~=2.0.0
+
     pydantic24: pydantic~=2.4.0
+    pydantic24: pydantic_settings~=2.0.0
+
     pydantic25: pydantic~=2.5.0
+    pydantic25: pydantic_settings~=2.1.0
+
     pydantic26: pydantic~=2.6.0
+    pydantic26: pydantic_settings~=2.1.0
+
     pydantic27: pydantic~=2.7.0
+    pydantic27: pydantic_settings~=2.2.0
+
     pydanticlatest: pydantic
+    pydanticlatest: pydantic_settings
 
     ; pins for sphinx 4.X compatibility from 
     ; https://github.com/sphinx-doc/sphinx/issues/11890


### PR DESCRIPTION
… version upgrades