### PR TITLE
refactor: Move extension setup logic into seperate `application` module

### DIFF
--- a/sphinxcontrib/autodoc_pydantic/__init__.py
+++ b/sphinxcontrib/autodoc_pydantic/__init__.py
@@ -1,36 +1,13 @@
-"""Contains the extension setup."""
-
 from __future__ import annotations
 
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
+
+from sphinxcontrib.autodoc_pydantic import application
 
 try:
     from importlib.metadata import version
 except ModuleNotFoundError:
     from importlib_metadata import version  # type: ignore[no-redef,import-not-found]
-
-from pydantic import BaseModel
-from sphinx.domains import ObjType
-
-from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
-    PydanticFieldDocumenter,
-    PydanticModelDocumenter,
-    PydanticSettingsDocumenter,
-    PydanticValidatorDocumenter,
-)
-from sphinxcontrib.autodoc_pydantic.directives.directives import (
-    PydanticField,
-    PydanticModel,
-    PydanticSettings,
-    PydanticValidator,
-)
-from sphinxcontrib.autodoc_pydantic.directives.options.enums import (
-    OptionsFieldDocPolicy,
-    OptionsJsonErrorStrategy,
-    OptionsSummaryListOrder,
-)
-from sphinxcontrib.autodoc_pydantic.events import add_fallback_css_class
 
 __version__ = version('autodoc_pydantic')
 
@@ -38,157 +15,12 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
-PRE = 'autodoc_pydantic_'
-
-
-class AppConfig(BaseModel):
-    name: str
-    default: Any
-    types: type
-    rebuild: Literal['env'] = 'env'
-
-
-APP_CONFIGURATIONS = [
-    # settings
-    AppConfig(name=f'{PRE}settings_show_json', default=True, types=bool),
-    AppConfig(
-        name=f'{PRE}settings_show_json_error_strategy',
-        default=OptionsJsonErrorStrategy.WARN,
-        types=str,
-    ),
-    AppConfig(name=f'{PRE}settings_show_config_summary', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_show_validator_members', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_show_validator_summary', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_show_field_summary', default=True, types=bool),
-    AppConfig(
-        name=f'{PRE}settings_summary_list_order',
-        default=OptionsSummaryListOrder.ALPHABETICAL,
-        types=str,
-    ),
-    AppConfig(name=f'{PRE}settings_hide_paramlist', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_hide_reused_validator', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_undoc_members', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_members', default=True, types=bool),
-    AppConfig(name=f'{PRE}settings_member_order', default='groupwise', types=str),
-    AppConfig(
-        name=f'{PRE}settings_signature_prefix',
-        default='pydantic settings',
-        types=str,
-    ),
-    # model
-    AppConfig(name=f'{PRE}model_show_json', default=True, types=bool),
-    AppConfig(
-        name=f'{PRE}model_show_json_error_strategy',
-        default=OptionsJsonErrorStrategy.WARN,
-        types=str,
-    ),
-    AppConfig(name=f'{PRE}model_show_config_summary', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_show_validator_members', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_show_validator_summary', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_show_field_summary', default=True, types=bool),
-    AppConfig(
-        name=f'{PRE}model_summary_list_order',
-        default=OptionsSummaryListOrder.ALPHABETICAL,
-        types=str,
-    ),
-    AppConfig(name=f'{PRE}model_hide_paramlist', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_hide_reused_validator', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_undoc_members', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_members', default=True, types=bool),
-    AppConfig(name=f'{PRE}model_member_order', default='groupwise', types=str),
-    AppConfig(name=f'{PRE}model_signature_prefix', default='pydantic model', types=str),
-    AppConfig(name=f'{PRE}model_erdantic_figure', default=False, types=bool),
-    AppConfig(name=f'{PRE}model_erdantic_figure_collapsed', default=True, types=bool),
-    # validator
-    AppConfig(name=f'{PRE}validator_signature_prefix', default='validator', types=str),
-    AppConfig(name=f'{PRE}validator_replace_signature', default=True, types=bool),
-    AppConfig(name=f'{PRE}validator_list_fields', default=False, types=bool),
-    # field
-    AppConfig(name=f'{PRE}field_list_validators', default=True, types=bool),
-    AppConfig(
-        name=f'{PRE}field_doc_policy', default=OptionsFieldDocPolicy.BOTH, types=str
-    ),
-    AppConfig(name=f'{PRE}field_show_constraints', default=True, types=bool),
-    AppConfig(name=f'{PRE}field_show_alias', default=True, types=bool),
-    AppConfig(name=f'{PRE}field_show_default', default=True, types=bool),
-    AppConfig(name=f'{PRE}field_show_required', default=True, types=bool),
-    AppConfig(name=f'{PRE}field_show_optional', default=True, types=bool),
-    AppConfig(name=f'{PRE}field_swap_name_and_alias', default=False, types=bool),
-    AppConfig(name=f'{PRE}field_signature_prefix', default='field', types=str),
-    # general
-    AppConfig(name=f'{PRE}add_fallback_css_class', default=True, types=bool),
-]
-
-
-def add_css_file(app: Sphinx, *_) -> None:  # noqa: ANN002
-    """Adds custom css to HTML output."""
-
-    filename = 'autodoc_pydantic.css'
-    static_path = (Path(app.outdir) / '_static').absolute()
-    static_path.mkdir(exist_ok=True, parents=True)
-    path_css = Path(__file__).parent.joinpath('css', filename)
-
-    if not (static_path / filename).exists():
-        content = path_css.read_text()
-        (static_path / filename).write_text(content)
-
-
-def add_domain_object_types(app: Sphinx) -> None:
-    """Hack to add object types to already instantiated python domain since
-    `add_object_type` currently only works for std domain.
-
-    """
-
-    object_types = app.registry.domain_object_types.setdefault('py', {})
-
-    obj_types_mapping = {
-        ('field', 'validator', 'config'): ('obj', 'any'),
-        ('model', 'settings'): ('obj', 'any', 'class'),
-    }
-
-    for obj_types, roles in obj_types_mapping.items():
-        for obj_type in obj_types:
-            object_types[f'pydantic_{obj_type}'] = ObjType(obj_type, *roles)
-
-
-def add_configuration_values(app: Sphinx) -> None:
-    """Adds all configuration values to sphinx application."""
-
-    for config in APP_CONFIGURATIONS:
-        app.add_config_value(
-            name=config.name,
-            default=config.default,
-            types=config.types,
-            rebuild=config.rebuild,
-        )
-
-
-def add_directives_and_autodocumenters(app: Sphinx) -> None:
-    """Adds custom pydantic directives and autodocumenters to sphinx
-    application.
-
-    """
-
-    app.add_directive_to_domain('py', 'pydantic_field', PydanticField)
-    app.add_directive_to_domain('py', 'pydantic_model', PydanticModel)
-    app.add_directive_to_domain('py', 'pydantic_settings', PydanticSettings)
-    app.add_directive_to_domain('py', 'pydantic_validator', PydanticValidator)
-
-    app.setup_extension('sphinx.ext.autodoc')
-    app.add_autodocumenter(PydanticFieldDocumenter)
-    app.add_autodocumenter(PydanticModelDocumenter)
-    app.add_autodocumenter(PydanticSettingsDocumenter)
-    app.add_autodocumenter(PydanticValidatorDocumenter)
-
-    app.connect('object-description-transform', add_fallback_css_class)
-
-
 def setup(app: Sphinx) -> dict[str, Any]:
-    add_configuration_values(app)
-    add_directives_and_autodocumenters(app)
-    add_domain_object_types(app)
+    application.add_configuration_values(app)
+    application.add_directives_and_autodocumenters(app)
+    application.add_domain_object_types(app)
     app.add_css_file('autodoc_pydantic.css')
-    app.connect('build-finished', add_css_file)
+    app.connect('build-finished', application.add_css_file)
 
     return {
         'version': __version__,

--- a/sphinxcontrib/autodoc_pydantic/application.py
+++ b/sphinxcontrib/autodoc_pydantic/application.py
@@ -1,0 +1,336 @@
+"""Contains the extension setup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel
+from sphinx.domains import ObjType
+
+from sphinxcontrib.autodoc_pydantic.directives import autodocumenters, directives
+from sphinxcontrib.autodoc_pydantic.directives.options import enums
+from sphinxcontrib.autodoc_pydantic.events import (
+    add_fallback_css_class,
+)
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+EXTENSION_PREFIX = 'autodoc_pydantic_'
+
+AUTODOCUMENTERS = [
+    autodocumenters.PydanticFieldDocumenter,
+    autodocumenters.PydanticModelDocumenter,
+    autodocumenters.PydanticSettingsDocumenter,
+    autodocumenters.PydanticValidatorDocumenter,
+]
+
+DOMAIN_DIRECTIVES = {
+    'pydantic_field': directives.PydanticField,
+    'pydantic_model': directives.PydanticModel,
+    'pydantic_settings': directives.PydanticSettings,
+    'pydantic_validator': directives.PydanticValidator,
+}
+
+
+class Config(BaseModel):
+    name: str
+    default: Any
+    types: type
+    rebuild: Literal['env'] = 'env'
+
+    @property
+    def full_name(self) -> str:
+        return f'{EXTENSION_PREFIX}{self.name}'
+
+
+# fmt: off
+APP_CONFIGURATIONS = [
+    # settings
+    Config(
+        name='settings_show_json',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_show_json_error_strategy',
+        default=enums.OptionsJsonErrorStrategy.WARN,
+        types=str,
+    ),
+    Config(
+        name='settings_show_config_summary',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_show_validator_members',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_show_validator_summary',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_show_field_summary',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_summary_list_order',
+        default=enums.OptionsSummaryListOrder.ALPHABETICAL,
+        types=str,
+    ),
+    Config(
+        name='settings_hide_paramlist',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_hide_reused_validator',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_undoc_members',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_members',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='settings_member_order',
+        default='groupwise',
+        types=str,
+    ),
+    Config(
+        name='settings_signature_prefix',
+        default='pydantic settings',
+        types=str,
+    ),
+
+    # model
+    Config(
+        name='model_show_json',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_show_json_error_strategy',
+        default=enums.OptionsJsonErrorStrategy.WARN,
+        types=str,
+    ),
+    Config(
+        name='model_show_config_summary',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_show_validator_members',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_show_validator_summary',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_show_field_summary',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_summary_list_order',
+        default=enums.OptionsSummaryListOrder.ALPHABETICAL,
+        types=str,
+    ),
+    Config(
+        name='model_hide_paramlist',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_hide_reused_validator',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_undoc_members',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_members',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='model_member_order',
+        default='groupwise',
+        types=str,
+    ),
+    Config(
+        name='model_signature_prefix',
+        default='pydantic model',
+        types=str,
+    ),
+    Config(
+        name='model_erdantic_figure',
+        default=False,
+        types=bool,
+    ),
+    Config(
+        name='model_erdantic_figure_collapsed',
+        default=True,
+        types=bool,
+    ),
+
+    # validator
+    Config(
+        name='validator_signature_prefix',
+        default='validator',
+        types=str,
+    ),
+    Config(
+        name='validator_replace_signature',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='validator_list_fields',
+        default=False,
+        types=bool,
+    ),
+
+    # field
+    Config(
+        name='field_list_validators',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='field_doc_policy',
+        default=enums.OptionsFieldDocPolicy.BOTH,
+        types=str,
+    ),
+    Config(
+        name='field_show_constraints',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='field_show_alias',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='field_show_default',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='field_show_required',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='field_show_optional',
+        default=True,
+        types=bool,
+    ),
+    Config(
+        name='field_swap_name_and_alias',
+        default=False,
+        types=bool,
+    ),
+    Config(
+        name='field_signature_prefix',
+        default='field',
+        types=str,
+    ),
+
+    # general
+    Config(
+        name='add_fallback_css_class',
+        default=True,
+        types=bool,
+    ),
+]
+# fmt: on
+
+
+OBJ_TYPES_MAPPING = {
+    ('field', 'validator', 'config'): (
+        'obj',
+        'any',
+    ),
+    ('model', 'settings'): (
+        'obj',
+        'any',
+        'class',
+    ),
+}
+
+
+def add_css_file(app: Sphinx, *_) -> None:  # noqa: ANN002
+    """Adds custom css to HTML output."""
+
+    filename = 'autodoc_pydantic.css'
+    static_path = (Path(app.outdir) / '_static').absolute()
+    static_path.mkdir(exist_ok=True, parents=True)
+    path_css = Path(__file__).parent.joinpath('css', filename)
+
+    if not (static_path / filename).exists():
+        content = path_css.read_text()
+        (static_path / filename).write_text(content)
+
+
+def add_domain_object_types(app: Sphinx) -> None:
+    """Hack to add object types to already instantiated python domain since
+    `add_object_type` currently only works for std domain.
+
+    """
+
+    object_types = app.registry.domain_object_types.setdefault('py', {})
+    for obj_types, roles in OBJ_TYPES_MAPPING.items():
+        for obj_type in obj_types:
+            object_types[f'pydantic_{obj_type}'] = ObjType(obj_type, *roles)
+
+
+def add_configuration_values(app: Sphinx) -> None:
+    """Adds all configuration values to sphinx application."""
+
+    for config in APP_CONFIGURATIONS:
+        app.add_config_value(
+            name=config.full_name,
+            default=config.default,
+            types=config.types,
+            rebuild=config.rebuild,
+        )
+
+
+def add_directives_and_autodocumenters(
+    app: Sphinx,
+) -> None:
+    """Adds custom pydantic directives and autodocumenters to sphinx
+    application.
+
+    """
+
+    for name, directive in DOMAIN_DIRECTIVES.items():
+        app.add_directive_to_domain('py', name, directive)
+
+    app.setup_extension('sphinx.ext.autodoc')
+    for autodocumenter in AUTODOCUMENTERS:
+        app.add_autodocumenter(autodocumenter)
+
+    app.connect(
+        'object-description-transform',
+        add_fallback_css_class,
+    )

--- a/tests/test_autosummary.py
+++ b/tests/test_autosummary.py
@@ -2,10 +2,10 @@ import pytest
 import sphinx
 from sphinx.ext.autosummary import FakeDirective
 
-from sphinxcontrib.autodoc_pydantic import (
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticFieldDocumenter,
     PydanticModelDocumenter,
     PydanticSettingsDocumenter,
-    PydanticFieldDocumenter,
     PydanticValidatorDocumenter,
 )
 

--- a/tests/test_configuration_fields.py
+++ b/tests/test_configuration_fields.py
@@ -3,24 +3,27 @@
 import pytest
 from sphinx.addnodes import (
     desc,
-    desc_signature,
-    desc_name,
-    desc_content,
-    desc_annotation,
     desc_addname,
+    desc_annotation,
+    desc_content,
+    desc_name,
+    desc_signature,
     index,
 )
 from sphinx.testing.util import assert_node
 
-from sphinxcontrib.autodoc_pydantic import PydanticFieldDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticFieldDocumenter,
+)
+
 from .compatibility import (
-    desc_annotation_default_value,
-    desc_annotation_directive_prefix,
-    convert_ellipsis_to_none,
     OPTIONAL_INT,
     TYPEHINTS_PREFIX,
     TYPING_MODULE_PREFIX_V1,
     TYPING_MODULE_PREFIX_V2,
+    convert_ellipsis_to_none,
+    desc_annotation_default_value,
+    desc_annotation_directive_prefix,
 )
 
 KWARGS = dict(documenter=PydanticFieldDocumenter.directivetype, deactivate_all=True)

--- a/tests/test_configuration_model.py
+++ b/tests/test_configuration_model.py
@@ -4,7 +4,10 @@ import pytest
 from sphinx.addnodes import desc_annotation
 from sphinx.testing.util import assert_node
 
-from sphinxcontrib.autodoc_pydantic import PydanticModelDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticModelDocumenter,
+)
+
 from .compatibility import desc_annotation_directive_prefix
 
 KWARGS = dict(documenter=PydanticModelDocumenter.objtype, deactivate_all=True)

--- a/tests/test_configuration_settings.py
+++ b/tests/test_configuration_settings.py
@@ -5,7 +5,9 @@ from typing import List
 from sphinx.addnodes import desc_annotation
 from sphinx.testing.util import assert_node
 
-from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import PydanticSettingsDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticSettingsDocumenter,
+)
 from .compatibility import desc_annotation_directive_prefix
 
 KWARGS = dict(documenter=PydanticSettingsDocumenter.objtype, deactivate_all=True)

--- a/tests/test_configuration_settings.py
+++ b/tests/test_configuration_settings.py
@@ -5,7 +5,7 @@ from typing import List
 from sphinx.addnodes import desc_annotation
 from sphinx.testing.util import assert_node
 
-from sphinxcontrib.autodoc_pydantic import PydanticSettingsDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import PydanticSettingsDocumenter
 from .compatibility import desc_annotation_directive_prefix
 
 KWARGS = dict(documenter=PydanticSettingsDocumenter.objtype, deactivate_all=True)

--- a/tests/test_configuration_validator.py
+++ b/tests/test_configuration_validator.py
@@ -15,7 +15,9 @@ from sphinx.addnodes import (
     index,
 )
 from sphinx.testing.util import assert_node
-from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import PydanticValidatorDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticValidatorDocumenter,
+)
 from .compatibility import desc_annotation_directive_prefix
 
 KWARGS = dict(documenter=PydanticValidatorDocumenter.objtype, deactivate_all=True)

--- a/tests/test_configuration_validator.py
+++ b/tests/test_configuration_validator.py
@@ -15,7 +15,7 @@ from sphinx.addnodes import (
     index,
 )
 from sphinx.testing.util import assert_node
-from sphinxcontrib.autodoc_pydantic import PydanticValidatorDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import PydanticValidatorDocumenter
 from .compatibility import desc_annotation_directive_prefix
 
 KWARGS = dict(documenter=PydanticValidatorDocumenter.objtype, deactivate_all=True)

--- a/tests/test_edgecases.py
+++ b/tests/test_edgecases.py
@@ -1,19 +1,20 @@
 """This module contains tests for edgecases."""
 
 import copy
-import sys
 
 import pytest
 import sphinx.errors
 from sphinx.transforms.post_transforms import ReferencesResolver
 
-from sphinxcontrib.autodoc_pydantic import PydanticModelDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticModelDocumenter,
+)
 from tests.compatibility import (
-    rst_alias_class_directive,
+    PYTHON_LT_310,
     TYPEHINTS_PREFIX,
     TYPING_MODULE_PREFIX_V2,
     module_doc_string_tab,
-    PYTHON_LT_310,
+    rst_alias_class_directive,
 )
 
 

--- a/tests/test_supported_types.py
+++ b/tests/test_supported_types.py
@@ -1,6 +1,8 @@
 import pytest
 
-from sphinxcontrib.autodoc_pydantic import PydanticModelDocumenter
+from sphinxcontrib.autodoc_pydantic.directives.autodocumenters import (
+    PydanticModelDocumenter,
+)
 
 
 @pytest.mark.parametrize('model_name', argvalues=['CookingModel'])


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Refactored the extension setup logic into a separate `application` module for better organization and readability.
- Created and implemented new configurations, directives, and autodocumenters within the `application` module.
- Updated all relevant test files to use the new module structure.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Refactor extension setup into new application module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/__init__.py
<li>Moved extensive configuration and setup logic to a new module <br><code>application.py</code>.<br> <li> Simplified the <code>setup</code> function by using the newly created module <br>functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-2c45a425561c96ca298973fe90efaa556380339cf8b9643593dd10ead6abd1bd">+7/-175</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>application.py</strong><dd><code>Implement new application module for extension setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sphinxcontrib/autodoc_pydantic/application.py
<li>Created a new module to handle configuration and setup logic for the <br>extension.<br> <li> Defined configuration settings, directives, and autodocumenters for <br>Sphinx.<br> <li> Added functions to manage CSS files and domain object types.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-8d59ef7971eeb25ef0cf070867772f97b4d051b70d60437d35bca13c80ac6943">+336/-0</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_autosummary.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_autosummary.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-4522a5b753241e32713c113f877f4b80f28e9d82012dc9c336fa96a4e9a889f9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_configuration_fields.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_configuration_fields.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-caa0fa6fe5dd8711dcc8e808983b3e984311502cd5f1b74f13f12a0d32d2f851">+11/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_configuration_model.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_configuration_model.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-af0c8816e931efee5f525854f1ae0346769b63224d93ba20d5d70c45bae488b0">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_configuration_settings.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_configuration_settings.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-dc8ef3d8044e644edca159b9e826ce53878a465c953e8364267d4fd4264eb1cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_configuration_validator.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_configuration_validator.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-2a086898e7ef156b231b9c9abc09c251e6e472c62a7f1f22f36394d1b6ef8013">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_edgecases.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_edgecases.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-73a52216dff9ee38057385009e82ea2a687989a7cf2f27e8e55414da44bf2148">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_supported_types.py</strong><dd><code>Update test imports for new module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_supported_types.py
- Updated import statements to reflect new module structure.



</details>
    

  </td>
  <td><a href="https://github.com/mansenfranzen/autodoc_pydantic/pull/264/files#diff-5dce5ef1fb70bffa6658705cc2ab8bf9f976fc61b061dfe1cd32f4f7133ea8c0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

