### PR TITLE
Remove upper Python version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 include = ["sphinxcontrib/autodoc_pydantic/css/autodoc_pydantic.css"]
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0.0"
+python = ">=3.8.1"
 Sphinx = ">=4.0"
 pydantic = ">=2.0,<3.0.0"
 pydantic-settings = ">=2.0,<3.0.0"


### PR DESCRIPTION
This PR removes the upper Python version constraint (`<4.0.0`) in `pyproject.toml`. 

The idea behind this change is that with this constraint one cannot simply install `autodoc_pydantic` in a downstream package that does not have such a constraint (see command output below). 

<details><summary>Click for command output</summary>

```
$ poetry add "autodoc_pydantic[erdantic]"
Using version ^2.2.0 for autodoc-pydantic

Updating dependencies
Resolving dependencies... (0.1s)

The current project's supported Python range (>=3.9) is not compatible with some of the required packages Python requirement:
  - autodoc-pydantic requires Python <4.0.0,>=3.8.1, so it will not be satisfied for Python >=4.0.0

Because no versions of autodoc-pydantic match >2.2.0,<3.0.0
 and autodoc-pydantic[erdantic] (2.2.0) requires Python <4.0.0,>=3.8.1, autodoc-pydantic is forbidden.
So, because test-package-template depends on autodoc-pydantic[erdantic] (^2.2.0), version solving failed.

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
    
    For autodoc-pydantic, a possible solution would be to set the `python` property to ">=3.9,<4.0.0"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```

</details>

Furthermore, other prominent packages also do not have this upper constrain, e.g. [FastAPI](https://github.com/tiangolo/fastapi/blob/ba1ac2b1f6689b1588b8bec33eb67d426d03abf1/pyproject.toml#L10), [rich](https://github.com/Textualize/rich/blob/349042fd8912ab5f0714ff9a46a70ef8a4be4700/pyproject.toml#L30), or [transformers](https://github.com/huggingface/transformers/blame/c8861376adee4c0f962918416dd356fdab552189/setup.py#L448), so it should be fine :slightly_smiling_face: 