### PR TITLE
Adding `field-show-examples` to show the examples for a field

### DIFF
--- a/docs/source/users/configuration.rst
+++ b/docs/source/users/configuration.rst
@@ -503,6 +503,17 @@ Fields
 
 
 .. config_description:: autopydantic_model
+   :title: Show Examples
+   :path: target.configuration.FieldShowExamples
+   :confpy: autodoc_pydantic_field_show_examples
+   :directive_option: field-show-examples
+   :enable: members, field-doc-policy=docstring
+   :values: True, False
+
+   Displays all examples that are associated with the given pydantic field.
+
+
+.. config_description:: autopydantic_model
    :title: Show Alias
    :path: target.configuration.FieldShowAlias
    :confpy: autodoc_pydantic_field_show_alias

--- a/sphinxcontrib/autodoc_pydantic/application.py
+++ b/sphinxcontrib/autodoc_pydantic/application.py
@@ -254,6 +254,11 @@ APP_CONFIGURATIONS = [
         default='field',
         types=str,
     ),
+    Config(
+        name='field_show_examples',
+        default=True,
+        types=bool,
+    ),
 
     # general
     Config(

--- a/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/autodocumenters.py
@@ -826,6 +826,24 @@ class PydanticFieldDocumenter(AttributeDocumenter):
         if self.pydantic.options.is_true('field-list-validators'):
             self.add_validators()
 
+        if self.pydantic.options.is_true('field-show-examples'):
+            self.add_examples()
+
+    def add_examples(self) -> None:
+        """Add section showing all defined examples for field."""
+
+        field_name = self.pydantic_field_name
+        examples = self.pydantic.inspect.fields.get_examples(field_name)
+
+        if examples:
+            source_name = self.get_sourcename()
+            self.add_line(':Examples:', source_name)
+            for value in examples:
+                line = f'   - {value}'
+                self.add_line(line, source_name)
+
+            self.add_line('', source_name)
+
     def add_constraints(self) -> None:
         """Adds section showing all defined constraints."""
 

--- a/sphinxcontrib/autodoc_pydantic/directives/options/definition.py
+++ b/sphinxcontrib/autodoc_pydantic/directives/options/definition.py
@@ -28,6 +28,7 @@ OPTIONS_FIELD: dict[str, Callable] = {
     'field-list-validators': option_default_true,
     'field-swap-name-and-alias': option_default_true,
     'field-doc-policy': option_one_of_factory(OptionsFieldDocPolicy.values()),
+    'field-show-examples': option_default_true,
     '__doc_disable_except__': option_list_like,
 }
 """Represents added directive options for :class:`PydanticFieldDocumenter`."""

--- a/sphinxcontrib/autodoc_pydantic/inspection.py
+++ b/sphinxcontrib/autodoc_pydantic/inspection.py
@@ -164,6 +164,17 @@ class FieldInspector(BaseInspectionComposite):
             if getattr(meta, key) is not None
         }
 
+    def has_examples(self, field_name:str) -> bool:
+        """Check if examples are provided in field info."""
+
+        return self.get_property_from_field_info(field_name, "examples") is not None
+
+    def get_examples(self, field_name: str) -> list[Any]:
+        """Get examples for given `field_name`."""
+        
+        if self.has_examples(field_name):
+            return self.get_property_from_field_info(field_name, 'examples')
+
     def is_required(self, field_name: str) -> bool:
         """Check if a given pydantic field is required/mandatory. Returns True,
         if a value for this field needs to provided upon model creation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ CONF_DEACTIVATE = {
     'autodoc_pydantic_validator_list_fields': False,
     'autodoc_pydantic_field_list_validators': False,
     'autodoc_pydantic_field_show_constraints': False,
+    'autodoc_pydantic_field_show_examples': False,
     'autodoc_pydantic_field_show_alias': False,
     'autodoc_pydantic_field_show_required': False,
     'autodoc_pydantic_field_show_optional': False,

--- a/tests/roots/test-base/target/configuration.py
+++ b/tests/roots/test-base/target/configuration.py
@@ -587,6 +587,20 @@ class FieldSwapNameAndAlias(BaseModel):
     """Field1"""
 
 
+class FieldShowExamples(BaseModel):
+    """FieldShowExamples."""
+
+    field: int = Field(1, examples=[2, 3])
+    """Field."""
+
+
+class FieldShowExamplesExtra(BaseModel):
+    """FieldShowExamplesExtra."""
+
+    field: int = Field(1, examples=[2, 3], json_schema_extra=dict(examples=[4, 5]))
+    """Field."""
+
+
 class ModelErdanticFigureRelated(ModelShowFieldSummary):
     """ModelErdanticFigureRelated."""
 

--- a/tests/roots/test-base/target/usage_automodule.py
+++ b/tests/roots/test-base/target/usage_automodule.py
@@ -21,6 +21,10 @@ class AutoModuleSettings(BaseSettings):
         default=5, ge=0, le=100, description='Shows constraints within doc string.'
     )
 
+    field_with_examples: int = Field(0, examples=[123, 546, 789])
+    """Shows examples within doc string."""
+
+
     @field_validator('field_with_validator_and_alias', 'field_plain_with_validator')
     def check_max_length_ten(cls, v):
         """Show corresponding field with link/anchor."""

--- a/tests/test_configuration_fields.py
+++ b/tests/test_configuration_fields.py
@@ -1632,3 +1632,95 @@ def test_autodoc_pydantic_field_swap_name_and_alias_true_directive_global(parse_
         },
     )
     assert_node(doctree, output_nodes)
+
+
+def test_autodoc_pydantic_field_show_examples_true(autodocument):
+    kwargs = dict(
+        object_path='target.configuration.FieldShowExamples.field', **KWARGS
+    )
+
+    result = [
+        '',
+        '.. py:pydantic_field:: FieldShowExamples.field',
+        '   :module: target.configuration',
+        '   :type: int',
+        '',
+        '   Field.',
+        '',
+        '   :Examples:',
+        '      - 2', 
+        '      - 3',
+        '',
+    ]
+
+    # explicit local
+    actual = autodocument(options_doc={'field-show-examples': True}, **kwargs)
+    assert result == actual
+
+    # explicit local overwrite global
+    actual = autodocument(
+        options_app={'autodoc_pydantic_field_show_examples': False},
+        options_doc={'field-show-examples': True},
+        **kwargs,
+    )
+    assert result == actual
+
+
+def test_autodoc_pydantic_field_show_examples_false(autodocument):
+    kwargs = dict(
+        object_path='target.configuration.FieldShowExamples.field', **KWARGS
+    )
+
+    result = [
+        '',
+        '.. py:pydantic_field:: FieldShowExamples.field',
+        '   :module: target.configuration',
+        '   :type: int',
+        '',
+        '   Field.',
+        '',
+    ]
+
+    # explicit local
+    actual = autodocument(options_doc={'field-show-examples': False}, **kwargs)
+    assert result == actual
+
+    # explicit local overwrite global
+    actual = autodocument(
+        options_app={'autodoc_pydantic_field_show_examples': True},
+        options_doc={'field-show-examples': False},
+        **kwargs,
+    )
+    assert result == actual
+
+
+def test_autodoc_pydantic_field_show_examples_ignore_extra(autodocument):
+    kwargs = dict(
+        object_path='target.configuration.FieldShowExamplesExtra.field', **KWARGS
+    )
+
+    result = [
+        '',
+        '.. py:pydantic_field:: FieldShowExamplesExtra.field',
+        '   :module: target.configuration',
+        '   :type: int',
+        '',
+        '   Field.',
+        '',
+        '   :Examples:',
+        '      - 2',
+        '      - 3',
+        '',
+    ]
+
+    # explicit local
+    actual = autodocument(options_doc={'field-show-examples': True}, **kwargs)
+    assert result == actual
+
+    # explicit local overwrite global
+    actual = autodocument(
+        options_app={'autodoc_pydantic_field_show_examples': False},
+        options_doc={'field-show-examples': True},
+        **kwargs,
+    )
+    assert result == actual


### PR DESCRIPTION
I will follow the [adding new features](https://autodoc-pydantic.readthedocs.io/en/stable/developers/guides.html#adding-new-features) guide to summarise this PR. 

### 1. Provide rationale

This PR follows the initial discussion in #186. It implements the [examples field](https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field) when available in a model. 
It should be enough to close #186. This PR won't handle cases where there are examples present in the `json_schema_extra` dictionary.

### 2. Specify the feature

The examples field is available in Pydantic and part of several projects (_e.g._ [FastAPI](https://github.com/fastapi/fastapi), [transformers](https://github.com/huggingface/transformers)). It provides additional context on the usage of the field. This is particularly important for complex models, but still useful in other cases.

### 3. Derive tests

The tests are implemented in `tests/test_configuration_fields.py`. Three tests were added:

- `tests/test_configuration_fields.py::test_autodoc_pydantic_field_show_examples_true`
- `tests/test_configuration_fields.py::test_autodoc_pydantic_field_show_examples_false`
- `tests/test_configuration_fields.py::test_autodoc_pydantic_field_show_examples_ignore_extra`

You can run them collective with the other tests using `poetry run pytest` or individually by using `poetry run pytest tests/test_configuration_fields.py::name_of_class`

The `conftest.py` was also updated to include the `False` default configuration and keep the behaviour of `CONF_DEACTIVATE` as expected.

### 4. Add configuration settings

A new boolean configuration was added called `field_show_examples`. The configuration behaves like all others `*show*` configurations accepting either `True` or `False` and it defaults to `True`.

### 5. Implement behaviour

The implemented behaviour was achieved with the support of `autodoc_pydantic/inspection.py::FieldInspector.has_examples` and `autodoc_pydantic/inspection.py::FieldInspector.get_examples`. The string to add the examples is generated by `autodoc_pydantic/directives/autodocumented.py::PydanticFieldDocumenter.add_examples` which is now ran in `autodoc_pydantic/directives/autodocumented.py::PydanticFieldDocumenter.add_content`

### 6. Update document

The documentation was updated to include the description in the `configuration.rst` and the default usage_automodule was also updated in `usage.rst` to showcase a simple field example with examples.
